### PR TITLE
Fix the blank mode-line issue when having a terminal and graphical frame open at the same time

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -269,7 +269,11 @@ static char * %s[] = {
 
 ;;;###autoload
 (defpowerline powerline-major-mode
-  (propertize mode-name
+  (propertize (typecase mode-name
+                (string mode-name)
+                (cons (if (first mode-name)
+                          (second mode-name)
+                        (third mode-name))))
               'help-echo "Major mode\n\ mouse-1: Display major mode menu\n\ mouse-2: Show help for major mode\n\ mouse-3: Toggle minor modes"
               'local-map (let ((map (make-sparse-keymap)))
                            (define-key map [mode-line down-mouse-1]


### PR DESCRIPTION
By keeping a separate memoization cache for every frame, one can use
graphical and terminal frames at the same time. Previously, opening a
terminal frame after opening a graphical frame would result in a blank
mode-line in the terminal frame.
