### PR TITLE
Require `cl` at runtime, too

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -10,7 +10,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl)
 
 (defvar powerline-buffer-size-suffix t)
 


### PR DESCRIPTION
This is necessary because `powerline-reset` (which indirectly uses
`gensym` from the `cl` package) is called at the `powerline` package's
toplevel. Without this patch it's not possible to load a byte-compiled
powerline.elc without having required `cl` before.
