### PR TITLE
Removed message. Fixed typo

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -118,7 +118,6 @@ destionation color, and 2 is the interpolated color between 0 and
     `(defun ,(intern (format "powerline-%s-%s" name (symbol-name dir)))
        (face1 face2 &optional height)
        (when window-system
-         (message "pl/ generating new separator")
          (unless height (setq height (pl/separator-height)))
          (let* ,(append
                  `((color1 (when ,src-face

--- a/powerline.el
+++ b/powerline.el
@@ -800,7 +800,7 @@ static char * %s[] = {
            (powerline-width (cdr values))))
     0))
 
-(message "powerlne loaded")
+(message "powerline loaded")
 
 (provide 'powerline)
 


### PR DESCRIPTION
When the ido mode is being used a message is displayed in the echo area overwriting what's being displayed. This happens on Emacs 24 on Ubuntu.
