### PR TITLE
Feature request: Themes on a separate file

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -1,51 +1,55 @@
 ;;; powerline-separators.el --- Separators for Powerline
 
-;; Copyright (c) 2013,2012 Donald Ephraim Curtis
-;; Copyright (c) 2013 Jason Milkins
-;; Copyright (c) 2012 Nicolas Rougier
+;; Copyright (C) 2012-2013 Donald Ephraim Curtis
+;; Copyright (C) 2013 Jason Milkins
+;; Copyright (C) 2012 Nicolas Rougier
 
 ;; Author: Donald Ephraim Curtis <dcurtis@milkbox.net>
-;; URL: http://github.com/milkypostman/powerline
+;; URL: http://github.com/milkypostman/powerline/
 ;; Version: 2.0
 ;; Keywords: mode-line
 
-
 ;;; Commentary:
-;; Powerline separators.
+;;
+;; Separators for Powerline.
+;; Included separators: alternate, arrow, arrow-fade, bar, box, brace, butt,
+;; chamfer, contour, curve, rounded, roundstub, slant, wave, zigzag, and nil.
+;;
 
 ;;; Code:
 
-(require 'cl)
 
 (defun pl/interpolate (color1 color2)
   "Interpolate between COLOR1 and COLOR2.
 
-COLOR1 and COLOR2 must be supplied as hex strings with leading #."
+COLOR1 and COLOR2 must be supplied as hex strings with a leading #."
   (let* ((c1 (replace-regexp-in-string "#" "" color1))
          (c2 (replace-regexp-in-string "#" "" color2))
-         (c1r (string-to-number (substring c1 0 2) 16)) (c1b (string-to-number (substring c1 2 4) 16)) (c1g (string-to-number (substring c1 4 6) 16))
-         (c2r (string-to-number (substring c2 0 2) 16)) (c2b (string-to-number (substring c2 2 4) 16)) (c2g (string-to-number (substring c2 4 6) 16))
-         (red (/ (+ c1r c2r) 2)) (grn (/ (+ c1g c2g) 2)) (blu (/ (+ c1b c2b) 2)))
-
-    (format "#%02X%02X%02X" red grn blu)))
-
+	 (c1r (string-to-number (substring c1 0 2) 16))
+	 (c1g (string-to-number (substring c1 4 6) 16))
+	 (c1b (string-to-number (substring c1 2 4) 16))
+	 (c2r (string-to-number (substring c2 0 2) 16))
+	 (c2g (string-to-number (substring c2 4 6) 16))
+	 (c2b (string-to-number (substring c2 2 4) 16))
+	 (red (/ (+ c1r c2r) 2))
+	 (green (/ (+ c1g c2g) 2))
+	 (blue (/ (+ c1b c2b) 2)))
+    (format "#%02X%02X%02X" red green blue)))
 
 (defun pl/hex-color (color)
-  "Gets the hexadecimal value COLOR."
+  "Get the hexadecimal value of COLOR."
   (let ((ret color))
-    (cond
-     ((and (stringp color) (string= "#" (substring color 0 1)))
-      (setq ret (upcase ret)))
-     ((color-defined-p color)
-      (setq ret (concat "#"
-                        (mapconcat
-                         (lambda(val)
-                           (format "%02X" (* val 255)))
-                         (color-name-to-rgb color) ""))))
-     (t (setq ret nil)))
+    (cond ((and (stringp color) (string= "#" (substring color 0 1)))
+	   (setq ret (upcase ret)))
+	  ((color-defined-p color)
+	   (setq ret (concat "#"
+			     (mapconcat (lambda (val)
+					  (format "%02X" (* val 255)))
+					(color-name-to-rgb color)
+					""))))
+	  (t
+	   (setq ret nil)))
     (symbol-value 'ret)))
-
-
 
 (defun pl/pattern (lst)
   "Turn LST into an infinite pattern."
@@ -53,284 +57,18 @@ COLOR1 and COLOR2 must be supplied as hex strings with leading #."
     (let ((pattern (copy-list lst)))
       (setcdr (last pattern) pattern))))
 
-
 (defun pl/pattern-to-string (pattern)
-  "Convert a PATTERN into a string that can be used in an xpm."
+  "Convert a PATTERN into a string that can be used in an XPM."
   (concat "\"" (mapconcat 'number-to-string pattern "") "\","))
-
 
 (defun pl/reverse-pattern (pattern)
   "Reverse each line in PATTERN."
   (mapcar 'reverse pattern))
 
-
-(defun pl/pattern-defun (name dir width &rest patterns)
-  "Create a powerline defun for NAME and DIR of WIDTH for given PATTERNS.
-
-PATTERNS is of the form (PATTERN HEADER FOOTER SECOND-PATTERN CENTER).
-PATTERN is required and all other compontents are optional.
-
-All generated functions generate the form,
-
-HEADER
-PATTERN ...
-CENTER
-SECOND-PATTERN ...
-FOOTER
-
-PATTERN and SECOND-PATTERN repeat infinitely to fill the needed
-space to generate a full height XPM.
-
-PATTERN, HEADER, FOOTER, SECOND-PATTERN, CENTER are of the
-form ((COLOR ...) (COLOR ...) ...)
-
-COLOR can be one of 0, 1, 2 where 0 is the source color, 1 is the
-destionation color, and 2 is the interpolated color between 0 and
-1."
-  (when (eq dir 'right) (setq patterns (mapcar 'pl/reverse-pattern patterns)))
-  (let* ((pattern (pl/pattern (mapcar 'pl/pattern-to-string (car patterns))))
-         (header (mapcar 'pl/pattern-to-string (nth 1 patterns)))
-         (footer (mapcar 'pl/pattern-to-string (nth 2 patterns)))
-         (second-pattern (pl/pattern (mapcar 'pl/pattern-to-string (nth 3 patterns))))
-         (center (mapcar 'pl/pattern-to-string (nth 4 patterns)))
-         (reserve (+ (length header) (length footer) (length center))))
-    (pl/wrap-defun
-     name dir width
-
-     `((pattern-height (max (- height ,reserve) 0))
-       (second-pattern-height (/ pattern-height 2))
-       (pattern-height ,(if second-pattern
-                            '(ceiling pattern-height 2)
-                          'pattern-height)))
-
-     `((mapconcat 'identity ',header "")
-       (mapconcat 'identity (subseq ',pattern 0 pattern-height) "")
-       (mapconcat 'identity ',center "")
-       (mapconcat 'identity (subseq ',second-pattern 0 second-pattern-height) "")
-       (mapconcat 'identity ',footer "")))))
-
-
-
-(defun pl/wrap-defun (name dir width let-vars body)
-  "Return powerline function list of NAME in DIR with WIDTH using LET-VARS and BODY."
-  (let* ((src-face (if (eq dir 'left) 'face1 'face2))
-         (dst-face (if (eq dir 'left) 'face2 'face1)))
-    `(defun ,(intern (format "powerline-%s-%s" name (symbol-name dir)))
-       (face1 face2 &optional height)
-       (when window-system
-         (message "pl/ generating new separator")
-         (unless height (setq height (pl/separator-height)))
-         (let* ,(append
-                 `((color1 (when ,src-face
-                             (pl/hex-color (face-attribute ,src-face :background))))
-                   (color2 (when ,dst-face
-                             (pl/hex-color (face-attribute ,dst-face :background))))
-                   (colori (when (and color1 color2) (pl/interpolate color1 color2)))
-                   (color1 (or color1 "None"))
-                   (color2 (or color2 "None"))
-                   (colori (or colori "None")))
-                 let-vars)
-           (create-image
-            ,(append
-              `(concat
-                (format "/* XPM */
-static char * %s_%s[] = {
-\"%s %s 3 1\",
-\"0 c %s\",
-\"1 c %s\",
-\"2 c %s\",
-"
-                        ,(replace-regexp-in-string "-" "_" name) (symbol-name ',dir)
-                        ,width height
-                        color1
-                        color2
-                        colori))
-              body
-              '("};"))
-            'xpm t :ascent 'center
-            :face (when (and face1 face2) ,dst-face)))))))
-
-
-
-(defmacro pl/nil (dir)
-  "Generate function to return nil XPM for DIR."
-  `(defun ,(intern (format "powerline-nil-%s" (symbol-name dir)))
-     (face1 face2 &optional height)
-     nil))
-
-
-(defmacro pl/bar (dir)
-  "Generate an bar xpm function for DIR."
-  (pl/pattern-defun
-   "bar" dir 2
-   '((2 2))))
-
-
-(defmacro pl/alternate (dir)
-  "Generate an alternating pattern xpm function for DIR."
-  (pl/pattern-defun
-   "alternate" dir 4
-   '((2 2 1 1)
-     (0 0 2 2))))
-
-
-(defmacro pl/zigzag (dir)
-  "Generate an zigzag pattern xpm function for DIR."
-  (pl/pattern-defun
-   "zigzag" dir 3
-   '((1 1 1)
-     (0 1 1)
-     (0 0 1)
-     (0 0 0)
-     (0 0 1)
-     (0 1 1))))
-
-
-(defmacro pl/box (dir)
-  "Generate an box xpm function for DIR."
-  (pl/pattern-defun
-   "box" dir 2
-   '((0 0)
-     (0 0)
-     (1 1)
-     (1 1))))
-
-(defmacro pl/curve (dir)
-  "Generate an curve xpm function for DIR."
-  (pl/pattern-defun
-   "curve" dir 4
-   '((0 0 0 0))
-   '((1 1 1 1)
-     (2 1 1 1)
-     (0 0 1 1)
-     (0 0 2 1)
-     (0 0 0 1)
-     (0 0 0 2))
-   '((0 0 0 2)
-     (0 0 0 1)
-     (0 0 2 1)
-     (0 0 1 1)
-     (2 1 1 1)
-     (1 1 1 1))))
-
-
-(defmacro pl/roundstub (dir)
-  "Generate an roundstub xpm function for DIR."
-  (pl/pattern-defun
-   "roundstub" dir 3
-   '((0 0 0))
-   '((1 1 1)
-     (0 0 1)
-     (0 0 2))
-   '((0 0 2)
-     (0 0 1)
-     (1 1 1))))
-
-(defmacro pl/butt (dir)
-  "Generate an butt xpm function for DIR."
-  (pl/pattern-defun
-   "butt" dir 3
-   '((0 0 0))
-   '((1 1 1)
-     (0 1 1)
-     (0 0 1))
-   '((0 0 1)
-     (0 1 1)
-     (1 1 1))))
-
-(defmacro pl/chamfer (dir)
-  "Generate an chamfer xpm function for DIR."
-  (pl/pattern-defun
-   "chamfer" dir 3
-   '((0 0 0))
-   '((1 1 1)
-     (0 1 1)
-     (0 0 1))))
-
-(defmacro pl/rounded (dir)
-  "Generate an rounded xpm function for DIR."
-  (pl/pattern-defun
-   "rounded" dir 6
-   '((0 0 0 0 0 0))
-   '((2 1 1 1 1 1)
-     (0 0 2 1 1 1)
-     (0 0 0 0 1 1)
-     (0 0 0 0 2 1)
-     (0 0 0 0 0 1)
-     (0 0 0 0 0 2))))
-
-(defmacro pl/contour (dir)
-  "Generate an contour xpm function for DIR."
-  (pl/pattern-defun
-   "contour" dir 10
-   '((0 0 0 0 0 1 1 1 1 1))
-
-   '((1 1 1 1 1 1 1 1 1 1)
-     (0 2 1 1 1 1 1 1 1 1)
-     (0 0 2 1 1 1 1 1 1 1)
-     (0 0 0 2 1 1 1 1 1 1)
-     (0 0 0 0 1 1 1 1 1 1)
-     (0 0 0 0 2 1 1 1 1 1))
-
-   '((0 0 0 0 0 2 1 1 1 1)
-     (0 0 0 0 0 0 1 1 1 1)
-     (0 0 0 0 0 0 2 1 1 1)
-     (0 0 0 0 0 0 0 2 1 1)
-     (0 0 0 0 0 0 0 0 0 0))))
-
-(defmacro pl/wave (dir)
-  "Generate an wave xpm function for DIR."
-  (pl/pattern-defun
-   "wave" dir 11
-   '((0 0 0 0 0 0 1 1 1 1 1 ))
-
-   '((2 1 1 1 1 1 1 1 1 1 1 )
-     (0 0 1 1 1 1 1 1 1 1 1 )
-     (0 0 0 1 1 1 1 1 1 1 1 )
-     (0 0 0 2 1 1 1 1 1 1 1 )
-     (0 0 0 0 1 1 1 1 1 1 1 )
-     (0 0 0 0 2 1 1 1 1 1 1 )
-     (0 0 0 0 0 1 1 1 1 1 1 )
-     (0 0 0 0 0 1 1 1 1 1 1 )
-     (0 0 0 0 0 2 1 1 1 1 1 ))
-
-   '((0 0 0 0 0 0 2 1 1 1 1 )
-     (0 0 0 0 0 0 0 1 1 1 1 )
-     (0 0 0 0 0 0 0 1 1 1 1 )
-     (0 0 0 0 0 0 0 2 1 1 1 )
-     (0 0 0 0 0 0 0 0 1 1 1 )
-     (0 0 0 0 0 0 0 0 2 1 1 )
-     (0 0 0 0 0 0 0 0 0 0 2 ))))
-
-(defmacro pl/brace (dir)
-  "Generate an brace xpm function for DIR."
-  (pl/pattern-defun
-   "brace" dir 4
-
-   '((0 1 1 1))
-
-   '((1 1 1 1)
-     (2 1 1 1))
-
-   '((2 1 1 1)
-     (1 1 1 1))
-
-   '((0 1 1 1))
-
-   '((0 2 1 1)
-     (0 2 1 1)
-     (0 0 2 1)
-     (0 0 0 0)
-     (0 0 2 1)
-     (0 2 1 1)
-     (0 2 1 1))))
-
-
-
-
 (defun pl/row-pattern (fill total &optional fade)
   "Make a list that has FILL 0s out of TOTAL 1s with FADE 2s to the right of the fill."
-  (unless fade (setq fade 0))
+  (unless fade
+    (setq fade 0))
   (let ((fill (min fill total))
         (fade (min fade (max (- total fill) 0))))
     (append (make-list fill 0)
@@ -338,6 +76,83 @@ static char * %s_%s[] = {
             (make-list (- total fill fade) 1))))
 
 
+(defun pl/pattern-defun (name dir width &rest patterns)
+  "Create a powerline function of NAME in DIR with WIDTH for PATTERNS.
+
+PATTERNS is of the form (PATTERN HEADER FOOTER SECOND-PATTERN CENTER).
+PATTERN is required, all other components are optional.
+
+All generated functions generate the form:
+HEADER
+PATTERN ...
+CENTER
+SECOND-PATTERN ...
+FOOTER
+
+PATTERN and SECOND-PATTERN repeat infinitely to fill the space needed to generate a full height XPM.
+
+PATTERN, HEADER, FOOTER, SECOND-PATTERN, CENTER are of the form ((COLOR ...) (COLOR ...) ...).
+
+COLOR can be one of 0, 1, or 2, where 0 is the source color, 1 is the
+destination color, and 2 is the interpolated color between 0 and 1."
+  (when (eq dir 'right)
+    (setq patterns (mapcar 'pl/reverse-pattern patterns)))
+  (let* ((pattern (pl/pattern (mapcar 'pl/pattern-to-string (car patterns))))
+         (header (mapcar 'pl/pattern-to-string (nth 1 patterns)))
+         (footer (mapcar 'pl/pattern-to-string (nth 2 patterns)))
+         (second-pattern (pl/pattern (mapcar 'pl/pattern-to-string (nth 3 patterns))))
+         (center (mapcar 'pl/pattern-to-string (nth 4 patterns)))
+         (reserve (+ (length header) (length footer) (length center))))
+    (pl/wrap-defun name dir width
+		   `((pattern-height (max (- height ,reserve) 0))
+		     (second-pattern-height (/ pattern-height 2))
+		     (pattern-height ,(if second-pattern '(ceiling pattern-height 2) 'pattern-height)))
+		   `((mapconcat 'identity ',header "")
+		     (mapconcat 'identity (subseq ',pattern 0 pattern-height) "")
+		     (mapconcat 'identity ',center "")
+		     (mapconcat 'identity (subseq ',second-pattern 0 second-pattern-height) "")
+		     (mapconcat 'identity ',footer "")))))
+
+(defun pl/wrap-defun (name dir width let-vars body)
+  "Generate a powerline function of NAME in DIR with WIDTH using LET-VARS and BODY."
+  (let* ((src-face (if (eq dir 'left) 'face1 'face2))
+         (dst-face (if (eq dir 'left) 'face2 'face1)))
+    `(defun ,(intern (format "powerline-%s-%s" name (symbol-name dir)))
+       (face1 face2 &optional height)
+       (when window-system
+         (message "pl/ generating new separator")
+	 (unless height
+	   (setq height (pl/separator-height)))
+	 (let* ,(append `((color1 (when ,src-face
+				    (pl/hex-color (face-attribute ,src-face :background))))
+			  (color2 (when ,dst-face
+				    (pl/hex-color (face-attribute ,dst-face :background))))
+			  (colori (when (and color1 color2) (pl/interpolate color1 color2)))
+			  (color1 (or color1 "None"))
+			  (color2 (or color2 "None"))
+			  (colori (or colori "None")))
+			let-vars)
+	   (create-image ,(append `(concat (format "/* XPM */ static char * %s_%s[] = { \"%s %s 3 1\", \"0 c %s\", \"1 c %s\", \"2 c %s\","
+						   ,(replace-regexp-in-string "-" "_" name)
+						   (symbol-name ',dir)
+						   ,width
+						   height
+						   color1
+						   color2
+						   colori))
+				  body
+				  '("};"))
+			 'xpm t
+			 :ascent 'center
+			 :face (when (and face1 face2)
+				 ,dst-face)))))))
+
+
+(defmacro pl/alternate (dir)
+  "Generate an alternating pattern XPM function for DIR."
+  (pl/pattern-defun "alternate" dir 4
+		    '((2 2 1 1)
+		      (0 0 2 2))))
 
 (defmacro pl/arrow (dir)
   "Generate an arrow XPM function for DIR."
@@ -347,40 +162,172 @@ static char * %s_%s[] = {
                      (middle-width (1- (ceiling height 2))))
                    `((loop for i from 0 to width
                            concat (pl/pattern-to-string (,row-modifier (pl/row-pattern i middle-width))))
-                     (when (oddp height) (pl/pattern-to-string (make-list middle-width 0)))
+		     (when (oddp height)
+		       (pl/pattern-to-string (make-list middle-width 0)))
                      (loop for i from width downto 0
-                           concat (pl/pattern-to-string (,row-modifier (pl/row-pattern i middle-width))))
-                     ))))
-
+			   concat (pl/pattern-to-string (,row-modifier (pl/row-pattern i middle-width))))))))
 
 (defmacro pl/arrow-fade (dir)
   "Generate an arrow-fade XPM function for DIR."
   (let* ((row-modifier (if (eq dir 'left) 'identity 'reverse)))
-    (pl/wrap-defun
-     "arrow-fade" dir 'middle-width
-     '((width (1- (/ height 2)))
-       (middle-width (1+ (ceiling height 2))))
-     `((loop for i from 0 to width
-             concat (pl/pattern-to-string (,row-modifier (pl/row-pattern i middle-width 2))))
-       (when (oddp height) (pl/pattern-to-string (,row-modifier (pl/row-pattern (1+ width) middle-width 2))))
-       (loop for i from width downto 0
-             concat (pl/pattern-to-string (,row-modifier (pl/row-pattern i middle-width 2))))))))
+    (pl/wrap-defun "arrow-fade" dir 'middle-width
+		   '((width (1- (/ height 2)))
+		     (middle-width (1+ (ceiling height 2))))
+		   `((loop for i from 0 to width
+			   concat (pl/pattern-to-string (,row-modifier (pl/row-pattern i middle-width 2))))
+		     (when (oddp height)
+		       (pl/pattern-to-string (,row-modifier (pl/row-pattern (1+ width) middle-width 2))))
+		     (loop for i from width downto 0
+			   concat (pl/pattern-to-string (,row-modifier (pl/row-pattern i middle-width 2))))))))
 
+(defmacro pl/bar (dir)
+  "Generate a bar XPM function for DIR."
+  (pl/pattern-defun "bar" dir 2
+		    '((2 2))))
+
+(defmacro pl/box (dir)
+  "Generate a box XPM function for DIR."
+  (pl/pattern-defun "box" dir 2
+		    '((0 0)
+		      (0 0)
+		      (1 1)
+		      (1 1))))
+
+(defmacro pl/brace (dir)
+  "Generate a brace XPM function for DIR."
+  (pl/pattern-defun "brace" dir 4
+		    '((0 1 1 1))
+		    '((1 1 1 1)
+		      (2 1 1 1))
+		    '((2 1 1 1)
+		      (1 1 1 1))
+		    '((0 1 1 1))
+		    '((0 2 1 1)
+		      (0 2 1 1)
+		      (0 0 2 1)
+		      (0 0 0 0)
+		      (0 0 2 1)
+		      (0 2 1 1)
+		      (0 2 1 1))))
+
+(defmacro pl/butt (dir)
+  "Generate a butt XPM function for DIR."
+  (pl/pattern-defun "butt" dir 3
+		    '((0 0 0))
+		    '((1 1 1)
+		      (0 1 1)
+		      (0 0 1))
+		    '((0 0 1)
+		      (0 1 1)
+		      (1 1 1))))
+
+(defmacro pl/chamfer (dir)
+  "Generate a chamfer XPM function for DIR."
+  (pl/pattern-defun "chamfer" dir 3
+		    '((0 0 0))
+		    '((1 1 1)
+		      (0 1 1)
+		      (0 0 1))))
+
+(defmacro pl/contour (dir)
+  "Generate a contour XPM function for DIR."
+  (pl/pattern-defun "contour" dir 10
+		    '((0 0 0 0 0 1 1 1 1 1))
+		    '((1 1 1 1 1 1 1 1 1 1)
+		      (0 2 1 1 1 1 1 1 1 1)
+		      (0 0 2 1 1 1 1 1 1 1)
+		      (0 0 0 2 1 1 1 1 1 1)
+		      (0 0 0 0 1 1 1 1 1 1)
+		      (0 0 0 0 2 1 1 1 1 1))
+		    '((0 0 0 0 0 2 1 1 1 1)
+		      (0 0 0 0 0 0 1 1 1 1)
+		      (0 0 0 0 0 0 2 1 1 1)
+		      (0 0 0 0 0 0 0 2 1 1)
+		      (0 0 0 0 0 0 0 0 0 0))))
+
+(defmacro pl/curve (dir)
+  "Generate a curve XPM function for DIR."
+  (pl/pattern-defun "curve" dir 4
+		    '((0 0 0 0))
+		    '((1 1 1 1)
+		      (2 1 1 1)
+		      (0 0 1 1)
+		      (0 0 2 1)
+		      (0 0 0 1)
+		      (0 0 0 2))
+		    '((0 0 0 2)
+		      (0 0 0 1)
+		      (0 0 2 1)
+		      (0 0 1 1)
+		      (2 1 1 1)
+		      (1 1 1 1))))
+
+(defmacro pl/rounded (dir)
+  "Generate a rounded XPM function for DIR."
+  (pl/pattern-defun "rounded" dir 6
+		    '((0 0 0 0 0 0))
+		    '((2 1 1 1 1 1)
+		      (0 0 2 1 1 1)
+		      (0 0 0 0 1 1)
+		      (0 0 0 0 2 1)
+		      (0 0 0 0 0 1)
+		      (0 0 0 0 0 2))))
+
+(defmacro pl/roundstub (dir)
+  "Generate a roundstub XPM function for DIR."
+  (pl/pattern-defun "roundstub" dir 3
+		    '((0 0 0))
+		    '((1 1 1)
+		      (0 0 1)
+		      (0 0 2))
+		    '((0 0 2)
+		      (0 0 1)
+		      (1 1 1))))
 
 (defmacro pl/slant (dir)
-  "Generate an slant XPM function for DIR."
+  "Generate a slant XPM function for DIR."
   (let* ((row-modifier (if (eq dir 'left) 'identity 'reverse)))
-    (pl/wrap-defun
-     "slant" dir 'width
-     '((width (1- (ceiling height 2))))
-     `((loop for i from 0 to height
-             concat (pl/pattern-to-string
-                     (,row-modifier (pl/row-pattern (/ i 2) width))))))))
+    (pl/wrap-defun "slant" dir 'width
+		   '((width (1- (ceiling height 2))))
+		   `((loop for i from 0 to height
+			   concat (pl/pattern-to-string (,row-modifier (pl/row-pattern (/ i 2) width))))))))
 
+(defmacro pl/wave (dir)
+  "Generate a wave XPM function for DIR."
+  (pl/pattern-defun "wave" dir 11
+		    '((0 0 0 0 0 0 1 1 1 1 1))
+		    '((2 1 1 1 1 1 1 1 1 1 1)
+		      (0 0 1 1 1 1 1 1 1 1 1)
+		      (0 0 0 1 1 1 1 1 1 1 1)
+		      (0 0 0 2 1 1 1 1 1 1 1)
+		      (0 0 0 0 1 1 1 1 1 1 1)
+		      (0 0 0 0 2 1 1 1 1 1 1)
+		      (0 0 0 0 0 1 1 1 1 1 1)
+		      (0 0 0 0 0 1 1 1 1 1 1)
+		      (0 0 0 0 0 2 1 1 1 1 1))
+		    '((0 0 0 0 0 0 2 1 1 1 1)
+		      (0 0 0 0 0 0 0 1 1 1 1)
+		      (0 0 0 0 0 0 0 1 1 1 1)
+		      (0 0 0 0 0 0 0 2 1 1 1)
+		      (0 0 0 0 0 0 0 0 1 1 1)
+		      (0 0 0 0 0 0 0 0 2 1 1)
+		      (0 0 0 0 0 0 0 0 0 0 2))))
 
+(defmacro pl/zigzag (dir)
+  "Generate a zigzag pattern XPM function for DIR."
+  (pl/pattern-defun "zigzag" dir 3
+		    '((1 1 1)
+		      (0 1 1)
+		      (0 0 1)
+		      (0 0 0)
+		      (0 0 1)
+		      (0 1 1))))
 
-
-
+(defmacro pl/nil (dir)
+  "Generate a XPM function that returns nil for DIR."
+  `(defun ,(intern (format "powerline-nil-%s" (symbol-name dir)))
+     (face1 face2 &optional height)
+     nil))
 
 
 (provide 'powerline-separators)

--- a/powerline-themes.el
+++ b/powerline-themes.el
@@ -1,0 +1,248 @@
+;;; powerline-themes.el --- Themes for Powerline
+
+;; Copyright (C) 2012-2013 Donald Ephraim Curtis
+;; Copyright (C) 2013 Jason Milkins
+;; Copyright (C) 2012 Nicolas Rougier
+
+;; Author: Donald Ephraim Curtis <dcurtis@milkbox.net>
+;; URL: http://github.com/milkypostman/powerline/
+;; Version: 2.0
+;; Keywords: mode-line
+
+;;; Commentary:
+;;
+;; Themes for Powerline.
+;; Included themes: default, center, center-evil, vim, and nano.
+;;
+
+;;; Code:
+
+
+;;;###autoload
+(defun powerline-default-theme ()
+  "Setup the default mode-line."
+  (interactive)
+  (setq-default mode-line-format
+                '("%e"
+		  (:eval
+		   (let* ((active (powerline-selected-window-active))
+			  (mode-line (if active 'mode-line 'mode-line-inactive))
+			  (face1 (if active 'powerline-active1 'powerline-inactive1))
+			  (face2 (if active 'powerline-active2 'powerline-inactive2))
+			  (separator-left (intern (format "powerline-%s-%s"
+							  powerline-default-separator
+							  (car powerline-default-separator-dir))))
+			  (separator-right (intern (format "powerline-%s-%s"
+							   powerline-default-separator
+							   (cdr powerline-default-separator-dir))))
+			  (lhs (list (powerline-raw "%*" nil 'l)
+				     (powerline-buffer-size nil 'l)
+				     (powerline-raw mode-line-mule-info nil 'l)
+				     (powerline-buffer-id nil 'l)
+				     (when (and (boundp 'which-func-mode) which-func-mode)
+				       (powerline-raw which-func-format nil 'l))
+				     (powerline-raw " ")
+				     (funcall separator-left mode-line face1)
+				     (when (boundp 'erc-modified-channels-object)
+				       (powerline-raw erc-modified-channels-object face1 'l))
+				     (powerline-major-mode face1 'l)
+				     (powerline-process face1)
+				     (powerline-minor-modes face1 'l)
+				     (powerline-narrow face1 'l)
+				     (powerline-raw " " face1)
+				     (funcall separator-left face1 face2)
+				     (powerline-vc face2 'r)))
+			  (rhs (list (powerline-raw global-mode-string face2 'r)
+				     (funcall separator-right face2 face1)
+				     (powerline-raw "%4l" face1 'l)
+				     (powerline-raw ":" face1 'l)
+				     (powerline-raw "%3c" face1 'r)
+				     (funcall separator-right face1 mode-line)
+				     (powerline-raw " ")
+				     (powerline-raw "%6p" nil 'r)
+				     (powerline-hud face2 face1))))
+		     (concat (powerline-render lhs)
+			     (powerline-fill face2 (powerline-width rhs))
+			     (powerline-render rhs)))))))
+
+;;;###autoload
+(defun powerline-center-theme ()
+  "Setup a mode-line with major and minor modes centered."
+  (interactive)
+  (setq-default mode-line-format
+                '("%e"
+                  (:eval
+                   (let* ((active (powerline-selected-window-active))
+                          (mode-line (if active 'mode-line 'mode-line-inactive))
+			  (face1 (if active 'powerline-active1 'powerline-inactive1))
+			  (face2 (if active 'powerline-active2 'powerline-inactive2))
+			  (separator-left (intern (format "powerline-%s-%s"
+							  powerline-default-separator
+							  (car powerline-default-separator-dir))))
+			  (separator-right (intern (format "powerline-%s-%s"
+							   powerline-default-separator
+							   (cdr powerline-default-separator-dir))))
+			  (lhs (list (powerline-raw "%*" nil 'l)
+				     (powerline-buffer-size nil 'l)
+				     (powerline-buffer-id nil 'l)
+				     (powerline-raw " ")
+				     (funcall separator-left mode-line face1)
+				     (powerline-narrow face1 'l)
+				     (powerline-vc face1)))
+			  (rhs (list (powerline-raw global-mode-string face1 'r)
+				     (powerline-raw "%4l" face1 'r)
+				     (powerline-raw ":" face1)
+				     (powerline-raw "%3c" face1 'r)
+				     (funcall separator-right face1 mode-line)
+				     (powerline-raw " ")
+				     (powerline-raw "%6p" nil 'r)
+				     (powerline-hud face2 face1)))
+			  (center (list (powerline-raw " " face1)
+					(funcall separator-left face1 face2)
+					(when (boundp 'erc-modified-channels-object)
+					  (powerline-raw erc-modified-channels-object face2 'l))
+					(powerline-major-mode face2 'l)
+					(powerline-process face2)
+					(powerline-raw " :" face2)
+					(powerline-minor-modes face2 'l)
+					(powerline-raw " " face2)
+					(funcall separator-right face2 face1))))
+		     (concat (powerline-render lhs)
+			     (powerline-fill-center face1 (/ (powerline-width center) 2.0))
+			     (powerline-render center)
+			     (powerline-fill face1 (powerline-width rhs))
+			     (powerline-render rhs)))))))
+
+(defun powerline-center-evil-theme ()
+  "Setup a mode-line with major, evil, and minor modes centered."
+  (interactive)
+  (setq mode-line-format
+        '("%e"
+          (:eval
+           (let* ((active (powerline-selected-window-active))
+                  (mode-line (if active 'mode-line 'mode-line-inactive))
+		  (face1 (if active 'powerline-active1 'powerline-inactive1))
+		  (face2 (if active 'powerline-active2 'powerline-inactive2))
+		  (separator-left (intern (format "powerline-%s-%s"
+						  powerline-default-separator
+						  (car powerline-default-separator-dir))))
+		  (separator-right (intern (format "powerline-%s-%s"
+						   powerline-default-separator
+						   (cdr powerline-default-separator-dir))))
+		  (lhs (list (powerline-raw "%*" nil 'l)
+			     (powerline-buffer-size nil 'l)
+			     (powerline-buffer-id nil 'l)
+			     (powerline-raw " ")
+			     (funcall separator-left mode-line face1)
+			     (powerline-narrow face1 'l)
+			     (powerline-vc face1)))
+		  (rhs (list (powerline-raw global-mode-string face1 'r)
+			     (powerline-raw "%4l" face1 'r)
+			     (powerline-raw ":" face1)
+			     (powerline-raw "%3c" face1 'r)
+			     (funcall separator-right face1 mode-line)
+			     (powerline-raw " ")
+			     (powerline-raw "%6p" nil 'r)
+			     (powerline-hud face2 face1)))
+		  (center (append (list (powerline-raw " " face1)
+					(funcall separator-left face1 face2)
+					(when (boundp 'erc-modified-channels-object)
+					  (powerline-raw erc-modified-channels-object face2 'l))
+					(powerline-major-mode face2 'l)
+					(powerline-process face2)
+					(powerline-raw " " face2))
+				  (if (split-string (format-mode-line minor-mode-alist))
+				      (append (if evil-mode
+						  (list (funcall separator-right face2 face1)
+							(powerline-raw evil-mode-line-tag face1 'l)
+							(powerline-raw " " face1)
+							(funcall separator-left face1 face2)))
+					      (list (powerline-minor-modes face2 'l)
+						    (powerline-raw " " face2)
+						    (funcall separator-right face2 face1)))
+				    (list (powerline-raw evil-mode-line-tag face2)
+					  (funcall separator-right face2 face1))))))
+	     (concat (powerline-render lhs)
+		     (powerline-fill-center face1 (/ (powerline-width center) 2.0))
+		     (powerline-render center)
+		     (powerline-fill face1 (powerline-width rhs))
+		     (powerline-render rhs)))))))
+
+;;;###autoload
+(defun powerline-vim-theme ()
+  "Setup a Vim-like mode-line."
+  (interactive)
+  (setq-default mode-line-format
+                '("%e"
+                  (:eval
+                   (let* ((active (powerline-selected-window-active))
+                          (mode-line (if active 'mode-line 'mode-line-inactive))
+			  (face1 (if active 'powerline-active1 'powerline-inactive1))
+			  (face2 (if active 'powerline-active2 'powerline-inactive2))
+			  (separator-left (intern (format "powerline-%s-%s"
+							  powerline-default-separator
+							  (car powerline-default-separator-dir))))
+			  (separator-right (intern (format "powerline-%s-%s"
+							   powerline-default-separator
+							   (cdr powerline-default-separator-dir))))
+			  (lhs (list (powerline-buffer-id `(mode-line-buffer-id ,mode-line) 'l)
+				     (powerline-raw "[" mode-line 'l)
+				     (powerline-major-mode mode-line)
+				     (powerline-process mode-line)
+				     (powerline-raw "]" mode-line)
+				     (when (buffer-modified-p)
+				       (powerline-raw "[+]" mode-line))
+				     (when buffer-read-only
+				       (powerline-raw "[RO]" mode-line))
+				     (powerline-raw "[%z]" mode-line)
+				     ;; (powerline-raw (concat "[" (mode-line-eol-desc) "]") mode-line)
+				     (when (and (boundp 'which-func-mode) which-func-mode)
+				       (powerline-raw which-func-format nil 'l))
+				     (when (boundp 'erc-modified-channels-object)
+				       (powerline-raw erc-modified-channels-object face1 'l))
+				     (powerline-raw "[" mode-line 'l)
+				     (powerline-minor-modes mode-line)
+				     (powerline-raw "%n" mode-line)
+				     (powerline-raw "]" mode-line)
+				     (when (and vc-mode buffer-file-name)
+				       (let ((backend (vc-backend buffer-file-name)))
+					 (when backend
+					   (concat (powerline-raw "[" mode-line 'l)
+						   (powerline-raw (format "%s / %s" backend (vc-working-revision buffer-file-name backend)))
+						   (powerline-raw "]" mode-line)))))))
+			  (rhs (list (powerline-raw '(10 "%i"))
+				     (powerline-raw global-mode-string mode-line 'r)
+				     (powerline-raw "%l," mode-line 'l)
+				     (powerline-raw (format-mode-line '(10 "%c")))
+				     (powerline-raw (replace-regexp-in-string  "%" "%%" (format-mode-line '(-3 "%p"))) mode-line 'r))))
+		     (concat (powerline-render lhs)
+			     (powerline-fill mode-line (powerline-width rhs))
+			     (powerline-render rhs)))))))
+
+;;;###autoload
+(defun powerline-nano-theme ()
+  "Setup a nano-like mode-line."
+  (interactive)
+  (setq-default mode-line-format
+                '("%e"
+                  (:eval
+                   (let* ((active (powerline-selected-window-active))
+			  (lhs (list (powerline-raw (concat "GNU Emacs "
+							    (number-to-string
+							     emacs-major-version)
+							    "."
+							    (number-to-string
+							     emacs-minor-version))
+						    nil 'l)))
+			  (rhs (list (if (buffer-modified-p) (powerline-raw "Modified" nil 'r))))
+			  (center (list (powerline-raw "%b" nil))))
+		     (concat (powerline-render lhs)
+			     (powerline-fill-center nil (/ (powerline-width center) 2.0))
+			     (powerline-render center)
+			     (powerline-fill nil (powerline-width rhs))
+			     (powerline-render rhs)))))))
+
+
+(provide 'powerline-themes)
+
+;;; powerline-themes.el ends here

--- a/powerline.el
+++ b/powerline.el
@@ -1,24 +1,27 @@
 ;;; powerline.el --- Rewrite of Powerline
 
-;; Copyright (c) 2013, 2012 Donald Ephraim Curtis
-;; Copyright (c) 2013 Jason Milkins
-;; Copyright (c) 2012 Nicolas Rougier
+;; Copyright (C) 2012-2013 Donald Ephraim Curtis
+;; Copyright (C) 2013 Jason Milkins
+;; Copyright (C) 2012 Nicolas Rougier
 
 ;; Author: Donald Ephraim Curtis <dcurtis@milkbox.net>
-;; URL: http://github.com/milkypostman/powerline
+;; URL: http://github.com/milkypostman/powerline/
 ;; Version: 2.1
 ;; Keywords: mode-line
 
-
 ;;; Commentary:
-;; Powerline is library and collection of predefined themes for
-;; customizing the mode-line.
+;;
+;; Powerline is a library for customizing the mode-line that is based on the Vim
+;; Powerline. A collection of predefined themes comes with the package.
+;;
 
 ;;; Code:
 
-(require 'cl)
+
+(require 'powerline-themes)
 
 (require 'powerline-separators)
+
 
 (defface powerline-active1 '((t (:background "grey22" :inherit mode-line)))
   "Powerline face 1."
@@ -44,22 +47,22 @@
 Valid Values: arrow, slant, chamfer, wave, brace, roundstub,
 zigzag, butt, rounded, contour, curve"
   :group 'powerline
-  :type '(choice
-          (const arrow)
-          (const arrow-fade)
-          (const slant)
-          (const chamfer)
-          (const alternate)
-          (const bar)
-          (const nil)
-          (const wave)
-          (const brace)
-          (const roundstub)
-          (const zigzag)
-          (const butt)
-          (const rounded)
-          (const contour)
-          (const curve)))
+  :type '(choice (const alternate)
+		 (const arrow)
+		 (const arrow-fade)
+		 (const bar)
+		 (const box)
+		 (const brace)
+		 (const butt)
+		 (const chamfer)
+		 (const contour)
+		 (const curve)
+		 (const rounded)
+		 (const roundstub)
+		 (const slant)
+		 (const wave)
+		 (const zigzag)
+		 (const nil)))
 
 (defcustom powerline-default-separator-dir '(left . right)
   "The separator direction to use for the default theme.
@@ -126,49 +129,47 @@ The memoization cache is frame-local."
              val
            (puthash key (apply ,func args) cache))))))
 
-
 (defun pl/separator-height ()
   "Get default height for rendering separators."
   (or powerline-height (frame-char-height)))
 
-
 (defun powerline-reset ()
   "Reset memoized functions."
   (interactive)
+  (pl/memoize (pl/alternate left))
+  (pl/memoize (pl/alternate right))
   (pl/memoize (pl/arrow left))
   (pl/memoize (pl/arrow right))
   (pl/memoize (pl/arrow-fade left))
   (pl/memoize (pl/arrow-fade right))
-  (pl/memoize (pl/slant left))
-  (pl/memoize (pl/slant right))
-  (pl/memoize (pl/chamfer left))
-  (pl/memoize (pl/chamfer right))
-  (pl/memoize (pl/alternate left))
-  (pl/memoize (pl/alternate right))
   (pl/memoize (pl/bar left))
   (pl/memoize (pl/bar right))
-  (pl/memoize (pl/nil left))
-  (pl/memoize (pl/nil right))
-  (pl/memoize (pl/zigzag left))
-  (pl/memoize (pl/zigzag right))
   (pl/memoize (pl/box left))
   (pl/memoize (pl/box right))
-  (pl/memoize (pl/wave left))
-  (pl/memoize (pl/wave right))
-  (pl/memoize (pl/roundstub left))
-  (pl/memoize (pl/roundstub right))
+  (pl/memoize (pl/brace left))
+  (pl/memoize (pl/brace right))
   (pl/memoize (pl/butt left))
   (pl/memoize (pl/butt right))
-  (pl/memoize (pl/rounded left))
-  (pl/memoize (pl/rounded right))
+  (pl/memoize (pl/chamfer left))
+  (pl/memoize (pl/chamfer right))
   (pl/memoize (pl/contour left))
   (pl/memoize (pl/contour right))
-  (pl/memoize (pl/curve right))
   (pl/memoize (pl/curve left))
-  (pl/memoize (pl/brace right))
-  (pl/memoize (pl/brace left))
-  (pl/reset-cache)
-  )
+  (pl/memoize (pl/curve right))
+  (pl/memoize (pl/rounded left))
+  (pl/memoize (pl/rounded right))
+  (pl/memoize (pl/roundstub left))
+  (pl/memoize (pl/roundstub right))
+  (pl/memoize (pl/slant left))
+  (pl/memoize (pl/slant right))
+  (pl/memoize (pl/wave left))
+  (pl/memoize (pl/wave right))
+  (pl/memoize (pl/zigzag left))
+  (pl/memoize (pl/zigzag right))
+  (pl/memoize (pl/nil left))
+  (pl/memoize (pl/nil right))
+  (pl/reset-cache))
+
 (powerline-reset)
 
 (defun pl/make-xpm (name color1 color2 data)
@@ -244,7 +245,6 @@ static char * %s[] = {
     (pl/percent-xpm height pmax pmin we ws
                     (* (frame-char-width) width) color1 color2)))
 
-
 ;;;###autoload
 (defun powerline-mouse (click-group click-type string)
   "Return mouse handler for CLICK-GROUP given CLICK-TYPE and STRING."
@@ -265,7 +265,6 @@ static char * %s[] = {
          `(lambda (event)
             (interactive "@e")
             nil))))
-
 
 ;;;###autoload
 (defun powerline-concat (&rest strings)
@@ -320,7 +319,6 @@ static char * %s[] = {
           (pl/add-text-property padded-str 'face face)
         padded-str))))
 
-
 ;;;###autoload
 (defun powerline-fill (face reserve)
   "Return empty space using FACE and leaving RESERVE space on the right."
@@ -344,7 +342,6 @@ static char * %s[] = {
               'display `((space :align-to (- (+ center (.5 . right-margin)) ,reserve
                                              (.5 . left-margin))))
               'face face))
-
 
 ;;;###autoload
 (defpowerline powerline-major-mode
@@ -380,8 +377,7 @@ static char * %s[] = {
                                           (powerline-mouse 'minor 'menu mm))
                                         map)))
              (split-string (format-mode-line minor-mode-alist))
-             (propertize " " 'face face)))
-
+	     (propertize " " 'face face)))
 
 ;;;###autoload
 (defpowerline powerline-narrow
@@ -403,7 +399,6 @@ static char * %s[] = {
   (when (and (buffer-file-name (current-buffer))
              vc-mode)
     (format-mode-line '(vc-mode vc-mode))))
-
 
 ;;;###autoload
 (defpowerline powerline-buffer-size
@@ -427,7 +422,6 @@ static char * %s[] = {
   (cond
    ((listp mode-line-process) (format-mode-line mode-line-process))
    (t mode-line-process)))
-
 
 (defvar pl/default-mode-line mode-line-format)
 
@@ -464,318 +458,6 @@ static char * %s[] = {
   (interactive)
   (setq-default mode-line-format pl/default-mode-line))
 
-(defun powerline-center-evil-theme ()
-  "Setup a default mode-line with major, evil and minor modes centered."
-  (interactive)
-  (setq mode-line-format
-        '("%e"
-          (:eval
-           (let* ((active (powerline-selected-window-active))
-                  (mode-line (if active 'mode-line 'mode-line-inactive))
-                  (face1 (if active 'powerline-active1
-                           'powerline-inactive1))
-                  (face2 (if active 'powerline-active2
-                           'powerline-inactive2))
-                  (separator-left
-                   (intern (format "powerline-%s-%s"
-                                   powerline-default-separator
-                                   (car powerline-default-separator-dir))))
-                  (separator-right
-                   (intern (format "powerline-%s-%s"
-                                   powerline-default-separator
-                                   (cdr powerline-default-separator-dir))))
-                  (lhs (list
-                        (powerline-raw "%*" nil 'l)
-                        (powerline-buffer-size nil 'l)
-                        (powerline-buffer-id nil 'l)
-
-                        (powerline-raw " ")
-                        (funcall separator-left mode-line face1)
-
-                        (powerline-narrow face1 'l)
-
-                        (powerline-vc face1)))
-                  (rhs (list
-                        (powerline-raw global-mode-string face1 'r)
-
-                        (powerline-raw "%4l" face1 'r)
-                        (powerline-raw ":" face1)
-                        (powerline-raw "%3c" face1 'r)
-
-                        (funcall separator-right face1 mode-line)
-                        (powerline-raw " ")
-                        (powerline-raw "%6p" nil 'r)
-                        (powerline-hud face2 face1)))
-                  (center
-                   (append (list
-                            (powerline-raw " " face1)
-                            (funcall separator-left face1 face2)
-                            (when (boundp 'erc-modified-channels-object)
-                              (powerline-raw erc-modified-channels-object
-                                             face2 'l))
-                            (powerline-major-mode face2 'l)
-                            (powerline-process face2)
-                            (powerline-raw " " face2))
-                           (if (split-string (format-mode-line minor-mode-alist))
-                               (append
-                                (if evil-mode
-                                    (list (funcall separator-right face2 face1)
-                                          (powerline-raw evil-mode-line-tag face1 'l)
-                                          (powerline-raw " " face1)
-                                          (funcall separator-left face1 face2)))
-                                (list (powerline-minor-modes face2 'l)
-                                      (powerline-raw " " face2)
-                                      (funcall separator-right face2 face1)))
-                             (list (powerline-raw evil-mode-line-tag face2)
-                                   (funcall separator-right face2 face1))))))
-
-             (concat
-              (powerline-render lhs)
-              (powerline-fill-center face1 (/ (powerline-width center)
-                                              2.0))
-              (powerline-render center)
-              (powerline-fill face1 (powerline-width rhs))
-              (powerline-render rhs)))))))
-
-
-;;;###autoload
-(defun powerline-default-theme ()
-  "Setup a default mode-line."
-  (interactive)
-  (setq-default mode-line-format
-                '("%e"
-                  (:eval
-                   (let* ((active (powerline-selected-window-active))
-                          (mode-line (if active 'mode-line 'mode-line-inactive))
-                          (face1 (if active 'powerline-active1
-                                   'powerline-inactive1))
-                          (face2 (if active 'powerline-active2
-                                   'powerline-inactive2))
-                          (separator-left
-                           (intern (format "powerline-%s-%s"
-                                           powerline-default-separator
-                                           (car powerline-default-separator-dir))))
-                          (separator-right
-                           (intern (format "powerline-%s-%s"
-                                           powerline-default-separator
-                                           (cdr powerline-default-separator-dir))))
-                          (lhs (list
-                                (powerline-raw "%*" nil 'l)
-                                (powerline-buffer-size nil 'l)
-
-                                (powerline-raw mode-line-mule-info nil 'l)
-                                (powerline-buffer-id nil 'l)
-
-                                (when (and (boundp 'which-func-mode) which-func-mode)
-                                  (powerline-raw which-func-format nil 'l))
-
-                                (powerline-raw " ")
-                                (funcall separator-left mode-line face1)
-
-                                (when (boundp 'erc-modified-channels-object)
-                                  (powerline-raw erc-modified-channels-object
-                                                 face1 'l))
-
-                                (powerline-major-mode face1 'l)
-                                (powerline-process face1)
-                                (powerline-minor-modes face1 'l)
-                                (powerline-narrow face1 'l)
-
-                                (powerline-raw " " face1)
-                                (funcall separator-left face1 face2)
-
-                                (powerline-vc face2 'r)))
-                          (rhs (list
-                                (powerline-raw global-mode-string face2 'r)
-
-                                (funcall separator-right face2 face1)
-
-                                (powerline-raw "%4l" face1 'l)
-                                (powerline-raw ":" face1 'l)
-                                (powerline-raw "%3c" face1 'r)
-
-                                (funcall separator-right face1 mode-line)
-                                (powerline-raw " ")
-
-                                (powerline-raw "%6p" nil 'r)
-
-                                (powerline-hud face2 face1))))
-                     (concat
-                      (powerline-render lhs)
-                      (powerline-fill face2 (powerline-width rhs))
-                      (powerline-render rhs)))))))
-
-;;;###autoload
-(defun powerline-vim-theme ()
-  "Setup a default mode-line."
-  (interactive)
-  (setq-default mode-line-format
-                '("%e"
-                  (:eval
-                   (let* ((active (powerline-selected-window-active))
-                          (mode-line (if active 'mode-line 'mode-line-inactive))
-                          (face1 (if active 'powerline-active1
-                                   'powerline-inactive1))
-                          (face2 (if active 'powerline-active2
-                                   'powerline-inactive2))
-                          (separator-left
-                           (intern (format "powerline-%s-%s"
-                                           powerline-default-separator
-                                           (car powerline-default-separator-dir))))
-                          (separator-right
-                           (intern (format "powerline-%s-%s"
-                                           powerline-default-separator
-                                           (cdr powerline-default-separator-dir))))
-                          (lhs (list
-                                (powerline-buffer-id `(mode-line-buffer-id ,mode-line) 'l)
-
-                                (powerline-raw "[" mode-line 'l)
-                                (powerline-major-mode mode-line)
-                                (powerline-process mode-line)
-                                (powerline-raw "]" mode-line)
-
-                                (when (buffer-modified-p)
-                                  (powerline-raw "[+]" mode-line))
-                                (when buffer-read-only
-                                  (powerline-raw "[RO]" mode-line))
-
-                                (powerline-raw "[%z]" mode-line)
-
-                                ;; (powerline-raw (concat "[" (mode-line-eol-desc) "]") mode-line)
-
-                                (when (and (boundp 'which-func-mode) which-func-mode)
-                                  (powerline-raw which-func-format nil 'l))
-
-
-                                (when (boundp 'erc-modified-channels-object)
-                                  (powerline-raw erc-modified-channels-object
-                                                 face1 'l))
-
-                                (powerline-raw "[" mode-line 'l)
-                                (powerline-minor-modes mode-line)
-                                (powerline-raw "%n" mode-line)
-                                (powerline-raw "]" mode-line)
-
-
-                                (when (and vc-mode buffer-file-name)
-                                  (let ((backend (vc-backend buffer-file-name)))
-                                    (when backend
-                                      (concat
-                                       (powerline-raw "[" mode-line 'l)
-                                       (powerline-raw (format "%s / %s" backend
-                                                              (vc-working-revision buffer-file-name backend)))
-                                       (powerline-raw "]" mode-line)))))))
-
-                          (rhs (list
-                                (powerline-raw '(10 "%i"))
-                                (powerline-raw global-mode-string mode-line 'r)
-                                (powerline-raw "%l," mode-line 'l)
-                                (powerline-raw (format-mode-line '(10 "%c")))
-
-                                (powerline-raw (replace-regexp-in-string  "%" "%%" (format-mode-line '(-3 "%p"))) mode-line 'r))))
-                     (concat
-                      (powerline-render lhs)
-                      (powerline-fill mode-line (powerline-width rhs))
-                      (powerline-render rhs)))))))
-
-
-;;;###autoload
-(defun powerline-center-theme ()
-  "Setup a default mode-line with major and minor modes centered."
-  (interactive)
-  (setq-default mode-line-format
-                '("%e"
-                  (:eval
-                   (let* ((active (powerline-selected-window-active))
-                          (mode-line (if active 'mode-line 'mode-line-inactive))
-                          (face1 (if active 'powerline-active1
-                                   'powerline-inactive1))
-                          (face2 (if active 'powerline-active2
-                                   'powerline-inactive2))
-                          (separator-left
-                           (intern (format "powerline-%s-%s"
-                                           powerline-default-separator
-                                           (car powerline-default-separator-dir))))
-                          (separator-right
-                           (intern (format "powerline-%s-%s"
-                                           powerline-default-separator
-                                           (cdr powerline-default-separator-dir))))
-                          (lhs (list
-                                (powerline-raw "%*" nil 'l)
-                                (powerline-buffer-size nil 'l)
-                                (powerline-buffer-id nil 'l)
-
-                                (powerline-raw " ")
-                                (funcall separator-left mode-line face1)
-
-                                (powerline-narrow face1 'l)
-
-                                (powerline-vc face1)))
-                          (rhs (list
-                                (powerline-raw global-mode-string face1 'r)
-
-                                (powerline-raw "%4l" face1 'r)
-                                (powerline-raw ":" face1)
-                                (powerline-raw "%3c" face1 'r)
-
-                                (funcall separator-right face1 mode-line)
-                                (powerline-raw " ")
-                                (powerline-raw "%6p" nil 'r)
-                                (powerline-hud face2 face1)))
-                          (center (list
-                                   (powerline-raw " " face1)
-                                   (funcall separator-left face1 face2)
-                                   (when (boundp 'erc-modified-channels-object)
-                                     (powerline-raw erc-modified-channels-object
-                                                    face2 'l))
-                                   (powerline-major-mode face2 'l)
-                                   (powerline-process face2)
-                                   (powerline-raw " :" face2)
-                                   (powerline-minor-modes face2 'l)
-                                   (powerline-raw " " face2)
-                                   (funcall separator-right face2 face1))))
-
-                     (concat
-                      (powerline-render lhs)
-                      (powerline-fill-center face1 (/ (powerline-width center)
-                                                      2.0))
-                      (powerline-render center)
-                      (powerline-fill face1 (powerline-width rhs))
-                      (powerline-render rhs)))))))
-
-
-;;;###autoload
-(defun powerline-nano-theme ()
-  "Setup a nano-like mode-line."
-  (interactive)
-  (setq-default mode-line-format
-                '("%e"
-                  (:eval
-                   (let* ((active (powerline-selected-window-active))
-                          (lhs (list
-                                (powerline-raw (concat
-                                                "GNU Emacs "
-                                                (number-to-string
-                                                 emacs-major-version)
-                                                "."
-                                                (number-to-string
-                                                 emacs-minor-version))
-                                               nil 'l)))
-                          (rhs (list
-                                (if (buffer-modified-p)
-                                    (powerline-raw "Modified" nil 'r))))
-                          (center (list
-                                   (powerline-raw "%b" nil))))
-
-                     (concat
-                      (powerline-render lhs)
-                      (powerline-fill-center nil (/ (powerline-width center)
-                                                    2.0))
-                      (powerline-render center)
-                      (powerline-fill nil (powerline-width rhs))
-                      (powerline-render rhs)))))))
-
-
 (defun pl/render (item)
   "Render a powerline ITEM."
   (cond
@@ -785,7 +467,7 @@ static char * %s[] = {
    (item item)))
 
 (defun powerline-render (values)
-  "Renter a list of powerline VALUES."
+  "Render a list of powerline VALUES."
   (mapconcat 'pl/render values ""))
 
 (defun powerline-width (values)
@@ -800,9 +482,7 @@ static char * %s[] = {
            (powerline-width (cdr values))))
     0))
 
-(message "powerlne loaded")
 
 (provide 'powerline)
-
 
 ;;; powerline.el ends here


### PR DESCRIPTION
I've moved the themes to a separate file, I also reorganized the powerline-separators.el file.
Other changes (didn't change any actual code):
- removed "(require 'cl)" -> you're not using any CL function and from emacs 24 onwards it's cl-lib.
- removed the "(message "powerlne loaded")" -> redudant, if emacs can't load the package you will know.
- custom powerline-default-separator wasn't including the box separator, it is now.
- enhanced some functions descriptions.

Possible bug:
- shouldn't line 139 of the new powerline-separators.el be ",height" instead of "height"?
