### PR TITLE
Update powerline.el

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -18,7 +18,6 @@
 
 ;;; Code:
 
-
 (require 'powerline-themes)
 (require 'powerline-separators)
 
@@ -412,7 +411,7 @@ static char * %s[] = {
                'mouse-1 (lambda () (interactive)
                           (setq powerline-buffer-size-suffix
                                 (not powerline-buffer-size-suffix))
-                          (redraw-modeline)))))
+                          (force-mode-line-update)))))
 
 ;;;###autoload
 (defpowerline powerline-buffer-id


### PR DESCRIPTION
In powerline-buffer-size:
powerline.el:414:38:Warning: `redraw-modeline' is an obsolete function (as of 24.3); use`force-mode-line-update' instead.
