### PR TITLE
Fix for *svn-status* buffer issue

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -420,6 +420,7 @@ static char * %s[] = {
 ;;;###autoload
 (defpowerline powerline-process
   (cond
+   ((symbolp mode-line-process) (symbol-value mode-line-process))
    ((listp mode-line-process) (format-mode-line mode-line-process))
    (t mode-line-process)))
 


### PR DESCRIPTION
Hi,

Powerline didn't work in ***svn-status**\* buffer (`M-x svn-status` command of `psvn.el`). The modeline went blank and the ***Messages**\* buffer had a new message:

```
Error during redisplay: (wrong-type-argument sequencep svn-status-mode-line-process) [X times]
```

It appears that `psvn.el` sets the value of `mode-line-process` variable like this:

```
  (setq mode-line-process 'svn-status-mode-line-process)
```

This commit seems to fix the issue. However, my elisp knowledge is limited, so if there is a better way to handle this, please do so.

Thanks,
Prakash
