### PR TITLE
adding a (require 'color) to the powerline-separators.

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -19,6 +19,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'color)
 
 (defun pl/interpolate (color1 color2)
   "Interpolate between COLOR1 and COLOR2.


### PR DESCRIPTION
I tried to byte-compile the powerline library which failed on my machine due to missing references to the color.el.
I managed to get it to work by adding an explicit (require 'color) to the powerline-seperators.el.
However I am not sure whether that will cause issues on pre 24 emacs versions.
