### PR TITLE
Improve background-color handling.

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -99,6 +99,14 @@ destination color, and 2 is the interpolated color between 0 and 1."
                      (mapconcat 'identity (cl-subseq ',second-pattern 0 second-pattern-height) "")
                      (mapconcat 'identity ',footer "")))))
 
+(defun pl/background-color (face)
+  (face-attribute face
+                  (if (face-attribute face :inverse-video nil 'default)
+                      :foreground
+                    :background)
+                  nil
+                  'default))
+
 (defun pl/wrap-defun (name dir width let-vars body)
   "Generate a powerline function of NAME in DIR with WIDTH using LET-VARS and BODY."
   (let* ((src-face (if (eq dir 'left) 'face1 'face2))
@@ -108,9 +116,9 @@ destination color, and 2 is the interpolated color between 0 and 1."
        (when window-system
          (unless height (setq height (pl/separator-height)))
          (let* ,(append `((color1 (when ,src-face
-                                    (pl/hex-color (face-background ,src-face))))
+                                    (pl/hex-color (pl/background-color ,src-face))))
                           (color2 (when ,dst-face
-                                    (pl/hex-color (face-background ,dst-face))))
+                                    (pl/hex-color (pl/background-color ,dst-face))))
                           (colori (when (and color1 color2) (pl/interpolate color1 color2)))
                           (color1 (or color1 "None"))
                           (color2 (or color2 "None"))
@@ -323,8 +331,9 @@ destination color, and 2 is the interpolated color between 0 and 1."
        (powerline-raw
 	(char-to-string ,(intern (format "powerline-utf-8-separator-%s"
 					 dir-name)))
-	(list :foreground (face-attribute ,src-face :background)
-	      :background (face-attribute ,dst-face :background))))))
+        (list :foreground (pl/background-color ,src-face)
+              :background (pl/background-color ,dst-face)
+              :inverse-video nil)))))
 
 
 (provide 'powerline-separators)


### PR DESCRIPTION
* when looking up background colors, pay attention to both face
  inheritance and inverse-video, so we get the color that is actually
  displayed as the background; and
* when using UTF-8 separators, ensure that `:inverse-video` is `nil` so
  the separator colors don’t end up reversed.

This is related to sellout/emacs-color-theme-solarized#115 and fixes #22
(although #22 is already closed).