### PR TITLE
FIX #87: Allow `pl/pattern-defun` to accept less patterns

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -93,11 +93,11 @@ destination color, and 2 is the interpolated color between 0 and 1."
                    `((pattern-height (max (- height ,reserve) 0))
                      (second-pattern-height (/ pattern-height 2))
                      (pattern-height ,(if second-pattern '(ceiling pattern-height 2) 'pattern-height)))
-                   `((mapconcat 'identity ',header "")
-                     (mapconcat 'identity (cl-subseq ',pattern 0 pattern-height) "")
-                     (mapconcat 'identity ',center "")
-                     (mapconcat 'identity (cl-subseq ',second-pattern 0 second-pattern-height) "")
-                     (mapconcat 'identity ',footer "")))))
+                   (list (when header `(mapconcat 'identity ',header ""))
+                         `(mapconcat 'identity (cl-subseq ',pattern 0 pattern-height) "")
+                         (when center `(mapconcat 'identity ',center ""))
+                         (when second-pattern `(mapconcat 'identity (cl-subseq ',second-pattern 0 second-pattern-height) ""))
+                         (when footer `(mapconcat 'identity ',footer ""))))))
 
 (defun pl/background-color (face)
   (face-attribute face


### PR DESCRIPTION
See #87. The problem shows up in emacs 25, in which it seems that `cl-subseq`
changes in such a way to not accept a nil sequence. The chamfer separator was generating nil sequences because of the absence of a second-pattern or footer pattern for example. 

This change fixes the problem for me and should be backwards compatible. All it does is check for the existence of header, center, etc. before adding them to the list in `pl/pattern-defun`