### PR TITLE
VC Glyph using UTF-8 character

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -106,6 +106,11 @@ This is needed to make sure that text is properly aligned."
   :group 'powerline
   :type 'boolean)
 
+(defcustom powerline-glyphs nil
+  "Enable/disable glyphs for powerline."
+  :group 'powerline
+  :type 'boolean)
+
 (defun pl/create-or-get-cache ()
   "Return a frame-local hash table that acts as a memoization cache for powerline. Create one if the frame doesn't have one yet."
   (let ((table (frame-parameter nil 'powerline-cache)))

--- a/powerline.el
+++ b/powerline.el
@@ -62,7 +62,7 @@ zigzag, butt, rounded, contour, curve"
                  (const slant)
                  (const wave)
                  (const zigzag)
-		 (const utf-8)
+                 (const utf-8)
                  (const nil)))
 
 (defcustom powerline-utf-8-separator-left #xe0b0
@@ -443,14 +443,13 @@ static char * %s[] = {
 
 ;;;###autoload (autoload 'powerline-vc "powerline")
 (defpowerline powerline-vc
+  (let ((file-name (buffer-file-name (current-buffer))))
   (when (and (buffer-file-name (current-buffer)) vc-mode)
-    (if window-system
-	(format-mode-line '(vc-mode vc-mode))
-      (let ((backend (vc-backend (buffer-file-name (current-buffer)))))
-	(when backend
-	  (format " %s %s"
-		  (char-to-string #xe0a0)
-		  (vc-working-revision (buffer-file-name (current-buffer)) backend)))))))
+    (if powerline-glyphs
+        (format " %s %s"
+                (char-to-string #xe0a0)
+                (vc-working-revision file-name (vc-backend file-name)))
+      (format-mode-line '(vc-mode vc-mode))))))
 
 ;;;###autoload (autoload 'powerline-buffer-size "powerline")
 (defpowerline powerline-buffer-size


### PR DESCRIPTION
Update `powerline-vc` to display vc-glyph  depending on the variable `powerline-glyph`.
It uses the UTF-8 character `#xe0a0`:
![screen shot 2015-09-24 at 15 31 48](https://cloud.githubusercontent.com/assets/8639179/10074633/6a064188-62d1-11e5-998e-4c478b04eeec.png)