### PR TITLE
Respect face remapping in separators

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -100,12 +100,16 @@ destination color, and 2 is the interpolated color between 0 and 1."
                          (when footer `(mapconcat 'identity ',footer ""))))))
 
 (defun pl/background-color (face)
-  (face-attribute face
-                  (if (face-attribute face :inverse-video nil 'default)
-                      :foreground
-                    :background)
-                  nil
-                  'default))
+  (let ((face face)
+	(fa (assoc face face-remapping-alist)))
+    (when fa
+      (setq face (car (cdr fa))))
+    (face-attribute face
+		    (if (face-attribute face :inverse-video nil 'default)
+			:foreground
+		      :background)
+		    nil
+		    'default)))
 
 (defun pl/wrap-defun (name dir width let-vars body)
   "Generate a powerline function of NAME in DIR with WIDTH using LET-VARS and BODY."


### PR DESCRIPTION
When adding face remapping, the background of the face is no longer correct.

This occurs in the flycheck-color-mode-line package: 

https://github.com/flycheck/flycheck-color-mode-line/issues/3

This should fix the issue.