### PR TITLE
More flexible faces customization

### DIFF
--- a/powerline-themes.el
+++ b/powerline-themes.el
@@ -40,6 +40,7 @@
                 '("%e"
                   (:eval
                    (let* ((active (powerline-selected-window-active))
+                          (mode-line-buffer-id (if active 'mode-line-buffer-id 'mode-line-buffer-id-inactive))
                           (mode-line (if active 'mode-line 'mode-line-inactive))
                           (face1 (if active 'powerline-active1 'powerline-inactive1))
                           (face2 (if active 'powerline-active2 'powerline-inactive2))
@@ -49,12 +50,12 @@
                           (separator-right (intern (format "powerline-%s-%s"
                                                            (powerline-current-separator)
                                                            (cdr powerline-default-separator-dir))))
-                          (lhs (list (powerline-raw "%*" nil 'l)
+                          (lhs (list (powerline-raw "%*" mode-line 'l)
                                      (when powerline-display-buffer-size
-                                       (powerline-buffer-size nil 'l))
+                                       (powerline-buffer-size mode-line 'l))
                                      (when powerline-display-mule-info
-                                       (powerline-raw mode-line-mule-info nil 'l))
-                                     (powerline-buffer-id nil 'l)
+                                       (powerline-raw mode-line-mule-info mode-line 'l))
+                                     (powerline-buffer-id mode-line-buffer-id 'l)
                                      (when (and (boundp 'which-func-mode) which-func-mode)
                                        (powerline-raw which-func-format nil 'l))
                                      (powerline-raw " ")
@@ -79,7 +80,7 @@
 				     (powerline-raw "%3c" face1 'r)
 				     (funcall separator-right face1 mode-line)
 				     (powerline-raw " ")
-				     (powerline-raw "%6p" nil 'r)
+				     (powerline-raw "%6p" mode-line 'r)
                                      (when powerline-display-hud
                                        (powerline-hud face2 face1)))))
 		     (concat (powerline-render lhs)

--- a/powerline-themes.el
+++ b/powerline-themes.el
@@ -95,6 +95,7 @@
 		'("%e"
 		  (:eval
 		   (let* ((active (powerline-selected-window-active))
+                          (mode-line-buffer-id (if active 'mode-line-buffer-id 'mode-line-buffer-id-inactive))
 			  (mode-line (if active 'mode-line 'mode-line-inactive))
 			  (face1 (if active 'powerline-active1 'powerline-inactive1))
 			  (face2 (if active 'powerline-active2 'powerline-inactive2))
@@ -104,9 +105,9 @@
 			  (separator-right (intern (format "powerline-%s-%s"
 							   (powerline-current-separator)
 							   (cdr powerline-default-separator-dir))))
-			  (lhs (list (powerline-raw "%*" nil 'l)
-				     (powerline-buffer-size nil 'l)
-				     (powerline-buffer-id nil 'l)
+			  (lhs (list (powerline-raw "%*" mode-line 'l)
+				     (powerline-buffer-size mode-line 'l)
+				     (powerline-buffer-id mode-line-buffer-id 'l)
 				     (powerline-raw " ")
 				     (funcall separator-left mode-line face1)
 				     (powerline-narrow face1 'l)
@@ -117,7 +118,7 @@
 				     (powerline-raw "%3c" face1 'r)
 				     (funcall separator-right face1 mode-line)
 				     (powerline-raw " ")
-				     (powerline-raw "%6p" nil 'r)
+				     (powerline-raw "%6p" mode-line 'r)
 				     (powerline-hud face2 face1)))
 			  (center (list (powerline-raw " " face1)
 					(funcall separator-left face1 face2)
@@ -142,6 +143,7 @@
 		'("%e"
 		  (:eval
 		   (let* ((active (powerline-selected-window-active))
+                          (mode-line-buffer-id (if active 'mode-line-buffer-id 'mode-line-buffer-id-inactive))
 			  (mode-line (if active 'mode-line 'mode-line-inactive))
 			  (face1 (if active 'powerline-active1 'powerline-inactive1))
 			  (face2 (if active 'powerline-active2 'powerline-inactive2))
@@ -151,9 +153,9 @@
 			  (separator-right (intern (format "powerline-%s-%s"
 							   (powerline-current-separator)
 							   (cdr powerline-default-separator-dir))))
-			  (lhs (list (powerline-raw "%*" nil 'l)
-				     (powerline-buffer-size nil 'l)
-				     (powerline-buffer-id nil 'l)
+			  (lhs (list (powerline-raw "%*" mode-line 'l)
+				     (powerline-buffer-size mode-line 'l)
+				     (powerline-buffer-id mode-line-buffer-id 'l)
 				     (powerline-raw " ")
 				     (funcall separator-left mode-line face1)
 				     (powerline-narrow face1 'l)
@@ -164,7 +166,7 @@
 				     (powerline-raw "%3c" face1 'r)
 				     (funcall separator-right face1 mode-line)
 				     (powerline-raw " ")
-				     (powerline-raw "%6p" nil 'r)
+				     (powerline-raw "%6p" mode-line 'r)
 				     (powerline-hud face2 face1)))
 			  (center (append (list (powerline-raw " " face1)
 						(funcall separator-left face1 face2)

--- a/powerline.el
+++ b/powerline.el
@@ -41,6 +41,11 @@
   "Powerline face 2."
   :group 'powerline)
 
+(defface mode-line-buffer-id-inactive
+  '((t (:inherit mode-line-buffer-id)))
+  "Powerline mode-line face"
+  :group 'powerline)
+
 (defcustom powerline-default-separator 'arrow
   "The separator to use for the default theme.
 
@@ -467,9 +472,13 @@ static char * %s[] = {
    "\\`[ \t\n\r]+" ""
    (replace-regexp-in-string "[ \t\n\r]+\\'" "" s)))
 
+(defun powerline-strip-text-properties (txt)
+  (set-text-properties 0 (length txt) nil txt)
+  txt)
+
 ;;;###autoload (autoload 'powerline-buffer-id "powerline")
 (defpowerline powerline-buffer-id
-    (powerline-trim (format-mode-line mode-line-buffer-identification)))
+    (powerline-strip-text-properties (powerline-trim (format-mode-line mode-line-buffer-identification))))
 
 ;;;###autoload (autoload 'powerline-process "powerline")
 (defpowerline powerline-process


### PR DESCRIPTION
Modifying foreground of one section of the powerline had the annoying effect of also affecting other sections.

Thus I modified the code so that one can set faces for each part of the display independently, for more flexible customization:

* added new face mode-line-buffer-id-inactive
* explicitly set face to each section of the powerline.

Not really sure for powerline-center-evil-theme, as I am not a user of evil-mode.

I did not touch which-func-mode's face since a) it already has its own and b) I couldn't manage to modify it anyways.

If you want me to modify my PR please feel free to send feedback :)

Here is a screenshot of what I wanted to achieve with these modifications:

![screenshot from 2016-05-25 13-52-29](https://cloud.githubusercontent.com/assets/6248219/15539000/1029281e-2280-11e6-82bf-964e4373108a.png)

I also modified [theme monokai](https://github.com/oneKelvinSmith/monokai-emacs.git) to get this effect.