### PR TITLE
powerline-vc: same vcs display in tty and gui emacs, using the UTF-8 'branch' char and the more compact and informative vc-mode variable

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -440,13 +440,9 @@ static char * %s[] = {
 ;;;###autoload (autoload 'powerline-vc "powerline")
 (defpowerline powerline-vc
   (when (and (buffer-file-name (current-buffer)) vc-mode)
-    (if window-system
-	(format-mode-line '(vc-mode vc-mode))
-      (let ((backend (vc-backend (buffer-file-name (current-buffer)))))
-	(when backend
 	  (format " %s %s"
 		  (char-to-string #xe0a0)
-		  (vc-working-revision (buffer-file-name (current-buffer)) backend)))))))
+		  (format-mode-line '(vc-mode vc-mode)))))
 
 ;;;###autoload (autoload 'powerline-buffer-size "powerline")
 (defpowerline powerline-buffer-size


### PR DESCRIPTION
See issue  #123