### PR TITLE
Use mode-line-buffer-identification variable instead of %b

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -474,7 +474,7 @@ static char * %s[] = {
   (powerline-raw
    (format-mode-line
     (concat " " (propertize
-		 "%b"
+		 (format-mode-line mode-line-buffer-identification)
 		 'face face
 		 'mouse-face 'mode-line-highlight
 		 'help-echo "Buffer name\n\ mouse-1: Previous buffer\n\ mouse-3: Next buffer"


### PR DESCRIPTION
Since the last version the mode-line-buffer-identification variable is not used anymore, instead the buffer identification is always set to the current buffer name "%b".
