### PR TITLE
Add encoding segment

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -456,6 +456,14 @@ static char * %s[] = {
 	      (char-to-string #xe0a0)
 	      (format-mode-line '(vc-mode vc-mode))))))
 
+;;;###autoload (autoload 'powerline-encoding "powerline")
+(defpowerline powerline-encoding
+  (let ((buf-coding (format "%s" buffer-file-coding-system)))
+    (if (string-match "\\(dos\\|unix\\|mac\\)" buf-coding)
+        (match-string 1 buf-coding)
+      buf-coding)))
+
+
 ;;;###autoload (autoload 'powerline-buffer-size "powerline")
 (defpowerline powerline-buffer-size
   (propertize


### PR DESCRIPTION
This commit adds an option to view the encoding of a file in
Powerline by taking the functionality from TheBB's Spaceline.
By adding something like 
`(powerline-encoding face2 'r)`

 to your custom powerline theme either "unix", "dos", "mac" or
"utf-8" will display in your Powerline with the selected
face, hopefully addressing issue #112 

![screen shot 2016-08-01 at 12 19 17 pm](https://cloud.githubusercontent.com/assets/7518085/17306432/df0b8322-57e4-11e6-8e51-47138f4a9e6e.png)
![screen shot 2016-08-01 at 12 19 48 pm](https://cloud.githubusercontent.com/assets/7518085/17306433/e1c14552-57e4-11e6-9f72-42e5fe21e9ce.png)
