### PR TITLE
Fix coloration artifacts

### DIFF
--- a/powerline-themes.el
+++ b/powerline-themes.el
@@ -50,10 +50,10 @@
                                        (powerline-buffer-size mode-line 'l))
                                      (when powerline-display-mule-info
                                        (powerline-raw mode-line-mule-info mode-line 'l))
-                                     (powerline-buffer-id mode-line-buffer-id 'l)
+                                     (powerline-buffer-id mode-line 'l)
                                      (when (and (boundp 'which-func-mode) which-func-mode)
                                        (powerline-raw which-func-format nil 'l))
-                                     (powerline-raw " ")
+                                     (powerline-raw " " mode-line)
                                      (funcall separator-left mode-line face1)
                                      (when (and (boundp 'erc-track-minor-mode) erc-track-minor-mode)
                                        (powerline-raw erc-modified-channels-object face1 'l))
@@ -74,7 +74,7 @@
 				     (powerline-raw ":" face1 'l)
 				     (powerline-raw "%3c" face1 'r)
 				     (funcall separator-right face1 mode-line)
-				     (powerline-raw " ")
+				     (powerline-raw " " mode-line)
 				     (powerline-raw "%6p" mode-line 'r)
                                      (when powerline-display-hud
                                        (powerline-hud face2 face1)))))


### PR DESCRIPTION
Fixes coloration artifacts which appear in the default theme when an XEmacs window looses focus.

This is what the unfocused mode line looks like before applying this change:
(the incorrectly colored sections are outlined in yellow)
![before2](https://cloud.githubusercontent.com/assets/5448053/21071645/9671038c-be6c-11e6-8bf9-5d6765fddfe8.png)

This how the modeline appears after the change:
![after](https://cloud.githubusercontent.com/assets/5448053/21071647/a55a6e4c-be6c-11e6-9486-24703f29cbda.png)