### PR TITLE
Add custom group parent and description

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -23,6 +23,10 @@
 
 (require 'cl-lib)
 
+(defgroup powerline nil
+  "Powerline mode-line customization."
+  :group 'mode-line)
+
 (defface powerline-active1 '((t (:background "grey22" :inherit mode-line)))
   "Powerline face 1."
   :group 'powerline)


### PR DESCRIPTION
This simply adds a description of the `powerline` group. It also makes it a child of the `mode-line` mode.