### PR TITLE
Add permission statement to library headers

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -4,6 +4,19 @@
 ;; Copyright (C) 2013 Jason Milkins
 ;; Copyright (C) 2012 Nicolas Rougier
 
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;;
 ;; Separators for Powerline.

--- a/powerline-themes.el
+++ b/powerline-themes.el
@@ -4,6 +4,19 @@
 ;; Copyright (C) 2013 Jason Milkins
 ;; Copyright (C) 2012 Nicolas Rougier
 
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;;
 ;; Themes for Powerline.

--- a/powerline.el
+++ b/powerline.el
@@ -10,6 +10,19 @@
 ;; Keywords: mode-line
 ;; Package-Requires: ((cl-lib "0.2"))
 
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 ;;
 ;; Powerline is a library for customizing the mode-line that is based on the Vim


### PR DESCRIPTION
As you know, I use some custom elisp to inspect the permission statement or License header keyword in the "main library".

If that fails, I use the `licensee` tool to determine the license specified by the `LICENSE` (or similar) file. If that fails I use the Github API to detect to ask them what license they detected. They also use `licensee` for that purpose, but apparently they have changed its configuration because sometimes it works for them but not for me.

The oddest case is when Github displays the license for a repository on the webpage, but over the API it claims that it was not able to detect the license. That's what is happening here.

To avoid the failing blackbox, I am adding the permission statements to the library headers. Doing that is a good idea regardless of this issue anyway.