### PR TITLE
Update the mode line when switching frames with window managers

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -559,7 +559,8 @@ static char * %s[] = {
 (defun powerline-set-selected-window ()
   "sets the variable `powerline-selected-window` appropriately"
   (when (not (minibuffer-window-active-p (frame-selected-window)))
-    (setq powerline-selected-window (frame-selected-window))))
+    (setq powerline-selected-window (frame-selected-window))
+    (force-mode-line-update)))
 
 (defun powerline-unset-selected-window ()
   "Unsets the variable `powerline-selected-window` and updates the modeline"


### PR DESCRIPTION
Fix https://github.com/milkypostman/powerline/issues/104.

Related issues/PRs:
  - https://github.com/milkypostman/powerline/issues/120
  - https://github.com/milkypostman/powerline/issues/104
  - https://github.com/milkypostman/powerline/pull/134