### PR TITLE
Set apple color space automatically

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -31,7 +31,8 @@
 
 (defvar powerline-image-apple-rgb
   (and (eq (window-system) 'ns)
-       (< 16
+       ns-use-srgb-colorspace
+       (< 11
           (string-to-number
            (car
             (split-string
@@ -39,7 +40,7 @@
                   (match-string-no-properties 1 system-configuration)) "\\.")))))
   "Boolean variable to determine whether to use Apple RGB colorspace to render images.
 
-t on macOS 10.12+, nil otherwise.
+t on macOS 10.7+ and `ns-use-srgb-colorspace' is t, nil otherwise.
 
 This variable is automatically set, there's no need to modify it.")
 

--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -29,7 +29,7 @@
 (require 'cl-lib)
 (require 'color)
 
-(defvar powerline-image-apple-rgb)
+(defvar powerline-image-apple-rgb (eq (window-system) 'ns))
 
 (defun pl/interpolate (color1 color2)
   "Interpolate between COLOR1 and COLOR2.

--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -34,10 +34,8 @@
        ns-use-srgb-colorspace
        (< 11
           (string-to-number
-           (car
-            (split-string
-             (and (string-match "darwin\\([0-9]+\\.[0-9]+\\.[0-9]+\\)" system-configuration)
-                  (match-string-no-properties 1 system-configuration)) "\\.")))))
+           (and (string-match "darwin\\([0-9]+\\)" system-configuration)
+                (match-string-no-properties 1 system-configuration)))))
   "Boolean variable to determine whether to use Apple RGB colorspace to render images.
 
 t on macOS 10.7+ and `ns-use-srgb-colorspace' is t, nil otherwise.

--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -29,7 +29,19 @@
 (require 'cl-lib)
 (require 'color)
 
-(defvar powerline-image-apple-rgb (eq (window-system) 'ns))
+(defvar powerline-image-apple-rgb
+  (and (eq (window-system) 'ns)
+       (< 16
+          (string-to-number
+           (car
+            (split-string
+             (and (string-match "darwin\\([0-9]+\\.[0-9]+\\.[0-9]+\\)" system-configuration)
+                  (match-string-no-properties 1 system-configuration)) "\\.")))))
+  "Boolean variable to determine whether to use Apple RGB colorspace to render images.
+
+t on macOS 10.12+, nil otherwise.
+
+This variable is automatically set, there's no need to modify it.")
 
 (defun pl/interpolate (color1 color2)
   "Interpolate between COLOR1 and COLOR2.

--- a/powerline.el
+++ b/powerline.el
@@ -138,15 +138,6 @@ This is needed to make sure that text is properly aligned."
   :group 'powerline
   :type 'boolean)
 
-(defcustom powerline-image-apple-rgb nil
-  "When t, Use Apple RGB colors for image generation.
-
-On MacOS, sRGB colors are used for all GUI elements, except for image generation
-which uses Apple RGB color space.  When this option is set, theme colors are
-converted to equivalent Apple RGB colors before image generation."
-  :group 'powerline
-  :type 'boolean)
-
 (defcustom powerline-gui-use-vcs-glyph nil
   "Display a unicode character to represent a version control system. Not always supported in GUI."
   :group 'powerline


### PR DESCRIPTION
Why introduce an option when it can be done automatically? :P 

This color space problem only ever exists on the NS port, so I'm pretty sure this is safe.

References: #54 #141 

https://developer.apple.com/documentation/appkit/nsdisplaygamut/nsdisplaygamutsrgb?language=objc

https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history