### PR TITLE
Use buffer-list-update-hook instead of advising select-window.

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -575,12 +575,7 @@ static char * %s[] = {
   "Call `powerline-set-selected-window'."
   (powerline-set-selected-window))
 
-(defadvice select-window (around powerline-select-window activate)
-  "Call `powerline-set-selected-window' when NORECORD is nil."
-  (prog1
-      ad-do-it
-    (unless norecord
-      (powerline-set-selected-window))))
+(add-hook 'buffer-list-update-hook #'powerline-set-selected-window)
 
 ;;;###autoload (autoload 'powerline-selected-window-active "powerline")
 (defun powerline-selected-window-active ()


### PR DESCRIPTION
Per the official docs of select-window if you want to call a function every time a window is selected you should use buffer-list-update-hook. It automatically does The Right Thing, gets called only when necessary and you don't need to pay attention to norecord arguments.

The correction isn't theoretical either, advising select-window can lead to nasty feedback loops as in https://github.com/Alexander-Miller/treemacs/issues/369.