### PR TITLE
Handle invalid color channel values from `pl/color-xyz-to-apply-rgb`

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -55,6 +55,7 @@ COLOR1 and COLOR2 must be supplied as hex strings with a leading #."
 
 (defun pl/apply-apple-gamma (V)
   "Apply Apple gamma correction to sRGB' value V"
+  (setq V (min 1.0 (max 0.0 (expt V (/ 1.8)))))
   (if (isnan V) 0.0 V))
 
 (defun pl/color-xyz-to-apple-rgb (X Y Z)

--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -53,12 +53,16 @@ COLOR1 and COLOR2 must be supplied as hex strings with a leading #."
          (blue (/ (+ (nth 2 c1) (nth 2 c2)) 2)))
     (color-rgb-to-hex red green blue)))
 
+(defun pl/apply-apple-gamma (V)
+  "Apply Apple gamma correction to sRGB' value V"
+  (if (isnan V) 0.0 V))
+
 (defun pl/color-xyz-to-apple-rgb (X Y Z)
   "Convert CIE X Y Z colors to Apple RGB color space."
   (let ((r (+ (* 3.2404542 X) (* -1.5371385 Y) (* -0.4985314 Z)))
         (g (+ (* -0.9692660 X) (* 1.8760108 Y) (* 0.0415560 Z)))
         (b (+ (* 0.0556434 X) (* -0.2040259 Y) (* 1.0572252 Z))))
-    (list (expt r (/ 1.8)) (expt g (/ 1.8)) (expt b (/ 1.8)))))
+    (mapcar 'pl/apply-apple-gamma (list r g b))))
 
 (defun pl/color-srgb-to-apple-rgb (red green blue)
   "Convert RED GREEN BLUE colors from sRGB color space to Apple RGB.


### PR DESCRIPTION
With the existing `pl/color-xyz-to-apply-rgb` function, it's possible that `pl/hex-color` will generate a `-0.0e+NaN` color channel value for certain colors, such as those with zero B and/or G values.  This will either result in an incorrect displayed color (e.g., in Emacs 26.2) or cause an error to be thrown (e.g., in Emacs 27.0).  It's also possible that `pl/color-xyz-to-apply-rgb` will generate color channel values slightly outside of the valid range of 0.0 - 1.0, though that doesn't seem to cause any particular issues for Emacs.

Screenshots below from a test function comparing the changes in this PR with master and the core `color-rgb-to-hex`.

Emacs 26.2:
![powerline-separators-PR-26 2](https://user-images.githubusercontent.com/6516937/62502118-ba518380-b7a2-11e9-8656-5272887812de.png)

Emacs 27.0:
![powerline-separators-PR-27 0](https://user-images.githubusercontent.com/6516937/62502119-bd4c7400-b7a2-11e9-960d-65fe62c1dd6a.png)

See https://gist.github.com/schellj/3a0ff288936322b59006d497bf607351 for the test function that I used for the screenshots above function (copy the PR `pl/color-xyz-to-apple-rgb` to `schellj/color-xyz-to-apple-rgb`).

I spent a long time (too much time) trying to figure out if the `pl/color-xyz-to-apply-rgb` matrix transformation was incorrect or if there was a better one, but that effort was unfruitful.  Thus, I opted to just catch and handle the invalid color channel values.