### PR TITLE
Fix scaling for powerline-hud image

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -289,7 +289,7 @@ static char * %s[] = {
                                 "\"};"
                               "\",\n")))
                        data))))
-     'xpm t :ascent 'center)))
+     'xpm t :scale t :ascent 'center)))
 
 (defun pl/percent-xpm
     (height pmax pmin winend winstart width color1 color2)


### PR DESCRIPTION
This is a fix to #176. 

The call to `powerline-hud` results in the same arguments being passed to `create-image` as in 26.3. The docs for `create-image` say:

> If the property ‘:scale’ is not given and the
> display has a high resolution (more exactly, when the average width of a
> character in the default font is more than 10 pixels), the image is
> automatically scaled up in proportion to the default font.

I don't know what changed for 27.1, but passing `:scale t` to `create-image` fixes the problem in 27.1 and doesn't seem to have any negative effect on 26.3.