### PR TITLE
The focus-in-hook and focus-out-hook are deprecated

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -562,12 +562,12 @@ static char * %s[] = {
 
 (add-hook 'window-configuration-change-hook 'powerline-set-selected-window)
 
-;; focus-in-hook was introduced in emacs v24.4.
-;; Gets evaluated in the last frame's environment.
-(add-hook 'focus-in-hook 'powerline-set-selected-window)
-
-;; focus-out-hook was introduced in emacs v24.4.
-(add-hook 'focus-out-hook 'powerline-unset-selected-window)
+;; Watch focus changes
+(add-function :after after-focus-change-function
+              (lambda ()
+                (if (frame-focus-state)
+                    (powerline-set-selected-window)
+                  (powerline-unset-selected-window))))
 
 ;; Executes after the window manager requests that the user's events
 ;; be directed to a different frame.

--- a/powerline.el
+++ b/powerline.el
@@ -563,11 +563,15 @@ static char * %s[] = {
 (add-hook 'window-configuration-change-hook 'powerline-set-selected-window)
 
 ;; Watch focus changes
-(add-function :after after-focus-change-function
-              (lambda ()
-                (if (frame-focus-state)
-                    (powerline-set-selected-window)
-                  (powerline-unset-selected-window))))
+(if (boundp 'after-focus-change-function)
+  (add-function :after after-focus-change-function
+		(lambda ()
+                  (if (frame-focus-state)
+                      (powerline-set-selected-window)
+                    (powerline-unset-selected-window))))
+  (with-no-warnings
+    (add-hook 'focus-in-hook 'powerline-set-selected-window)
+    (add-hook 'focus-out-hook 'powerline-unset-selected-window)))
 
 ;; Executes after the window manager requests that the user's events
 ;; be directed to a different frame.


### PR DESCRIPTION
The official replacement is the after-focus-change-function used
here. It is working on my local copy.