### PR TITLE
Change :scale arugment from t to 1

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -204,7 +204,7 @@ destination color, and 2 is the interpolated color between 0 and 1."
                            '("};"))
                   'xpm t
                   :ascent 'center
-                  :scale t
+                  :scale 1
                   :face (when (and face1 face2)
                           ,dst-face)
                   ,(and body-2x

--- a/powerline.el
+++ b/powerline.el
@@ -289,7 +289,7 @@ static char * %s[] = {
                                 "\"};"
                               "\",\n")))
                        data))))
-     'xpm t :scale t :ascent 'center)))
+     'xpm t :scale 1 :ascent 'center)))
 
 (defun pl/percent-xpm
     (height pmax pmin winend winstart width color1 color2)


### PR DESCRIPTION
t is no longer accepted as :scale argument for create-image, but using 1
has the same behavior as before.

Fixes #184.