### PR TITLE
Disable powerline-image-apple-rgb on Emacs 28

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -31,16 +31,19 @@
 
 (defvar powerline-image-apple-rgb
   (and (eq (window-system) 'ns)
-       ns-use-srgb-colorspace
+       (bound-and-true-p ns-use-srgb-colorspace)
        (< 11
           (string-to-number
            (and (string-match "darwin\\([0-9]+\\)" system-configuration)
-                (match-string-no-properties 1 system-configuration)))))
+                (match-string-no-properties 1 system-configuration))))
+       (< emacs-major-version 28))
   "Boolean variable to determine whether to use Apple RGB colorspace to render images.
 
 t on macOS 10.7+ and `ns-use-srgb-colorspace' is t, nil otherwise.
 
-This variable is automatically set, there's no need to modify it.")
+This variable is automatically set, there's no need to modify it.
+
+Obsolete since Emacs 28.")
 
 (defun pl/interpolate (color1 color2)
   "Interpolate between COLOR1 and COLOR2.


### PR DESCRIPTION
Emacs 28 has [enabled](https://github.com/emacs-mirror/emacs/commit/3a3226716b84c29c7eee9e19054ffe7618bd334c) SRGB support for images on the NS port, so converting from generic RGB to sRGB is no longer necessary. This fixes an issue where the separator images are off color on the NS port of emacs 28.
