### PR TITLE
Fix #187 replace circular list to enable native compilation

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -99,9 +99,9 @@ RED, GREEN and BLUE should be between 0.0 and 1.0, inclusive."
     (setq fade 0))
   (let ((fill (min fill total))
         (fade (min fade (max (- total fill) 0))))
-    (append (make-list fill 0)
-            (make-list fade 2)
-            (make-list (- total fill fade) 1))))
+    (nconc (make-list fill 0)
+           (make-list fade 2)
+           (make-list (- total fill fade) 1))))
 
 (defun pl/pattern-bindings-body (patterns height-exp pattern-height-sym
                                           second-pattern-height-sym)

--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -122,16 +122,14 @@ for let-var binding variables."
       (cons `((,pattern-height-sym (max (- ,height-exp ,reserve) 0))
               (,second-pattern-height-sym (/ ,pattern-height-sym 2))
               (,pattern-height-sym ,(if second-pattern `(ceiling ,pattern-height-sym 2) `,pattern-height-sym)))
-            (list (when header `(mapconcat 'identity ',header ""))
-                  `(concat (cl-loop for i to ,pattern-height-sym
-                                    concat (ring-ref ',pattern i))
-                           "")
-                  (when center `(mapconcat 'identity ',center ""))
+            (list (when header `(apply 'concat ',header))
+                  `(cl-loop for i to ,pattern-height-sym
+                            concat (ring-ref ',pattern i))
+                  (when center `(apply 'concat ',center))
                   (when second-pattern
-                    `(concat (cl-loop for i to ,second-pattern-height-sym
-                                      concat (ring-ref ',second-pattern i))
-                             ""))
-                  (when footer `(mapconcat 'identity ',footer "")))))))
+                    `(cl-loop for i to ,second-pattern-height-sym
+                              concat (ring-ref ',second-pattern i)))
+                  (when footer `(apply 'concat ',footer)))))))
 
 (defun pl/pattern-defun (name dir width &rest patterns)
   "Create a powerline function of NAME in DIR with WIDTH for PATTERNS.

--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -80,10 +80,7 @@ RED, GREEN and BLUE should be between 0.0 and 1.0, inclusive."
 (defun pl/pattern (lst)
   "Turn LST into an infinite pattern."
   (when lst
-    (let ((r (make-ring (length lst))))
-      (dolist (e lst)
-        (ring-insert-at-beginning r e))
-      r)))
+    (ring-convert-sequence-to-ring lst)))
 
 (defun pl/pattern-to-string (pattern)
   "Convert a PATTERN into a string that can be used in an XPM."


### PR DESCRIPTION
Replace the circular list in pl/pattern with a ring so the new and shiny JIT can compile powerline. Added some minor memory optimizations too.