### PR TITLE
powerline-buffer-id: Avoid double-expanding %-escapes

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -516,16 +516,15 @@ Leave RESERVE space on the right."
 ;;;###autoload (autoload 'powerline-buffer-id "powerline")
 (defun powerline-buffer-id (&optional face pad)
   (powerline-raw
-   (format-mode-line
-    (concat " " (propertize
-                 (format-mode-line mode-line-buffer-identification)
-                 'face face
-                 'mouse-face 'mode-line-highlight
-                 'help-echo "Buffer name\n\ mouse-1: Previous buffer\n\ mouse-3: Next buffer"
-                 'local-map (let ((map (make-sparse-keymap)))
-                              (define-key map [mode-line mouse-1] 'mode-line-previous-buffer)
-                              (define-key map [mode-line mouse-3] 'mode-line-next-buffer)
-                              map))))
+   '(" " (:propertize
+          mode-line-buffer-identification
+          'face face
+          'mouse-face 'mode-line-highlight
+          'help-echo "Buffer name\n\ mouse-1: Previous buffer\n\ mouse-3: Next buffer"
+          'local-map (let ((map (make-sparse-keymap)))
+                       (define-key map [mode-line mouse-1] 'mode-line-previous-buffer)
+                       (define-key map [mode-line mouse-3] 'mode-line-next-buffer)
+                       map)))
    face pad))
 
 ;;;###autoload (autoload 'powerline-process "powerline")


### PR DESCRIPTION
Formerly, powerline-buffer-id would call format-mode-line multiple
times on the mode-line-buffer-identification, which was wrong in the
case of buffer names that include percent signs.

I'm not sure, based on the limited documentation, whether the `powerline-*` functions promise to return something suitable to be included in a mode-line-format, or whether they are designed to be interpolated as raw strings (which would require escaping them first).  I assumed the latter for this PR.

Fixes #152.