### PR TITLE
Fix byte-compiler warnings on Emacs 28

### DIFF
--- a/powerline-separators.el
+++ b/powerline-separators.el
@@ -39,7 +39,7 @@
              (and (string-match "darwin\\([0-9]+\\)" system-configuration)
                   (match-string-no-properties 1 system-configuration)))))
        (< emacs-major-version 28))
-  "Boolean variable to determine whether to use Apple RGB colorspace to render images.
+  "If non-nil, use Apple RGB colorspace to render images.
 
 t on macOS 10.7+ and `ns-use-srgb-colorspace' is t, nil otherwise.
 
@@ -92,7 +92,7 @@ RED, GREEN and BLUE should be between 0.0 and 1.0, inclusive."
   (mapcar 'reverse pattern))
 
 (defun pl/row-pattern (fill total &optional fade)
-  "Make a list that has FILL 0s out of TOTAL 1s with FADE 2s to the right of the fill."
+  "Return list that has FILL 0s out of TOTAL 1s with FADE 2s to the right."
   (unless fade
     (setq fade 0))
   (let ((fill (min fill total))
@@ -149,12 +149,15 @@ CENTER
 SECOND-PATTERN ...
 FOOTER
 
-PATTERN and SECOND-PATTERN repeat infinitely to fill the space needed to generate a full height XPM.
+PATTERN and SECOND-PATTERN repeat infinitely to fill the space
+needed to generate a full height XPM.
 
-PATTERN, HEADER, FOOTER, SECOND-PATTERN, CENTER are of the form ((COLOR ...) (COLOR ...) ...).
+PATTERN, HEADER, FOOTER, SECOND-PATTERN, CENTER are of the
+form ((COLOR ...) (COLOR ...) ...).
 
-COLOR can be one of 0, 1, or 2, where 0 is the source color, 1 is the
-destination color, and 2 is the interpolated color between 0 and 1."
+COLOR can be one of 0, 1, or 2, where 0 is the source color, 1 is
+the destination color, and 2 is the interpolated color between 0
+and 1."
   (when (eq dir 'right)
     (setq patterns (mapcar 'pl/reverse-pattern patterns)))
   (let ((bindings-body (pl/pattern-bindings-body patterns

--- a/powerline.el
+++ b/powerline.el
@@ -140,7 +140,8 @@ This is needed to make sure that text is properly aligned."
   :type 'boolean)
 
 (defcustom powerline-gui-use-vcs-glyph nil
-  "Display a unicode character to represent a version control system. Not always supported in GUI."
+  "Display a unicode character to represent a version control system.
+Not always supported in GUI."
   :group 'powerline
   :type 'boolean)
 
@@ -150,7 +151,8 @@ This is needed to make sure that text is properly aligned."
   :type 'string)
 
 (defun pl/create-or-get-cache ()
-  "Return a frame-local hash table that acts as a memoization cache for powerline. Create one if the frame doesn't have one yet."
+  "Return a frame-local hash table that acts as a memoization cache for powerline.
+Create one if the frame doesn't have one yet."
   (let ((table (frame-parameter nil 'powerline-cache)))
     (if (hash-table-p table) table (pl/reset-cache))))
 
@@ -182,7 +184,8 @@ This is needed to make sure that text is properly aligned."
   (set-frame-parameter frame 'powerline-cache nil))
 
 (defun powerline-desktop-save-delete-cache ()
-  "Set all caches to nil unless `frameset-filter-alist' has :never for powerline-cache."
+  "Set all caches to nil.
+This is not done if `frameset-filter-alist' has :never for powerline-cache."
   (unless (and (boundp 'frameset-filter-alist)
                (eq (cdr (assq 'powerline-cache frameset-filter-alist))
                    :never))
@@ -260,7 +263,8 @@ The memoization cache is frame-local."
 (powerline-reset)
 
 (defun pl/make-xpm (name color1 color2 data)
-  "Return an XPM image with NAME using COLOR1 for enabled and COLOR2 for disabled bits specified in DATA."
+  "Return an XPM image with NAME using COLOR1 and COLOR2 bits specified in DATA.
+COLOR1 signifies enabled, and COLOR2 signifies disabled."
   (when window-system
     (create-image
      (concat
@@ -296,7 +300,8 @@ static char * %s[] = {
 
 (defun pl/percent-xpm
     (height pmax pmin winend winstart width color1 color2)
-  "Generate percentage xpm of HEIGHT for PMAX to PMIN given WINEND and WINSTART with WIDTH and COLOR1 and COLOR2."
+  "Generate percentage xpm of HEIGHT for PMAX to PMIN given WINEND and WINSTART.
+Use WIDTH and COLOR1 and COLOR2."
   (let* ((height- (1- height))
          (fillstart (round (* height- (/ (float winstart) (float pmax)))))
          (fillend (round (* height- (/ (float winend) (float pmax)))))
@@ -316,7 +321,7 @@ static char * %s[] = {
 
 ;;;###autoload
 (defun powerline-hud (face1 face2 &optional width)
-  "Return an XPM of relative buffer location using FACE1 and FACE2 of optional WIDTH."
+  "Return XPM of relative buffer location using FACE1 and FACE2 of optional WIDTH."
   (unless width (setq width 2))
   (let ((color1 (if face1 (face-background face1) "None"))
         (color2 (if face2 (face-background face2) "None"))
@@ -394,7 +399,8 @@ static char * %s[] = {
 
 ;;;###autoload
 (defun powerline-raw (str &optional face pad)
-  "Render STR as mode-line data using FACE and optionally PAD import on left (l) or right (r)."
+  "Render STR as mode-line data using FACE and optionally PAD import.
+PAD can be left (`l') or right (`r')."
   (when str
     (let* ((rendered-str (format-mode-line str))
            (padded-str (concat
@@ -420,7 +426,8 @@ static char * %s[] = {
               'face face))
 
 (defun powerline-fill-center (face reserve)
-  "Return empty space using FACE to the center of remaining space leaving RESERVE space on the right."
+  "Return empty space using FACE to center of remaining space.
+Leave RESERVE space on the right."
   (unless reserve
     (setq reserve 20))
   (when powerline-text-scale-factor


### PR DESCRIPTION
This fixes some byte-compiler warnings on Emacs 28.

```
Compiling file /home/skangas/wip/emacs-packages/powerline/powerline.el at Mon Jan  3 03:54:46 2022
Entering directory ‘/home/skangas/wip/emacs-packages/powerline/’
powerline.el:142:1: Warning: custom-declare-variable
    `powerline-gui-use-vcs-glyph' docstring wider than 80 characters

In pl/create-or-get-cache:
powerline.el:152:8: Warning: docstring wider than 80 characters

In powerline-desktop-save-delete-cache:
powerline.el:184:8: Warning: docstring wider than 80 characters

In pl/make-xpm:
powerline.el:262:8: Warning: docstring wider than 80 characters

In pl/percent-xpm:
powerline.el:297:8: Warning: docstring wider than 80 characters

In powerline-hud:
powerline.el:318:8: Warning: docstring wider than 80 characters

In powerline-raw:
powerline.el:396:8: Warning: docstring wider than 80 characters

In powerline-fill-center:
powerline.el:422:8: Warning: docstring wider than 80 characters
```

```
Compiling file /home/skangas/wip/emacs-packages/powerline/powerline-separators.el at Mon Jan  3 04:00:17 2022
powerline-separators.el:33:1: Warning: defvar `powerline-image-apple-rgb'
    docstring wider than 80 characters

In pl/row-pattern:
powerline-separators.el:94:8: Warning: docstring wider than 80 characters

In pl/pattern-defun:
powerline-separators.el:132:8: Warning: docstring wider than 80 characters
```